### PR TITLE
update test for cv.VideoCapture.fromFile

### DIFF
--- a/test/video_test.dart
+++ b/test/video_test.dart
@@ -188,7 +188,7 @@ void main() async {
     final (success, frame) = vc.read();
     expect(success, true);
     expect(frame.isEmpty, false);
-    expect(vc.codec, isNotEmpty);
+    expect(vc.codec, "h264");
 
     expect(cv.VideoCapture.toCodec("h264"), closeTo(875967080, 1e-3));
     // cv.imwrite("cv.VideoCapture.fromFile.png", frame);


### PR DESCRIPTION
fix: 
- #31 

MacOS brew updates ffmpeg to 7, however this package is compiled with ffmpeg@6, Mac users can install ffmpeg@6 and link it:

`brew install ffmpeg@6`

`brew link --overwrite ffmpeg@6`

This PR checks the read video file format
https://github.com/rainyl/opencv_dart/blob/af7a0e6883841447d0e210fe198e1cfbc7f004a0/test/video_test.dart#L191