### PR TITLE
fix macos x64 build

### DIFF
--- a/.github/workflows/build_test_release.yaml
+++ b/.github/workflows/build_test_release.yaml
@@ -174,7 +174,7 @@ jobs:
           dart test -x no-local-files
   build-macos:
     name: build-macos
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Github recently changed macos-latest to macos 14 arm64, https://github.com/actions/runner-images/issues/9766