### PR TITLE
bump version of archive from 3.4.10 to 3.5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   yaml: ^3.1.2
   path: ^1.9.0
   args: ^2.4.2
-  archive: ^3.4.10
+  archive: ^3.5.1
 
 dev_dependencies:
   ffigen: ^11.0.0


### PR DESCRIPTION
setup fails on archive>3.5.0 due to an API change, https://pub.dev/packages/archive/changelog#350---april-26-2024 
```dart
void extractArchiveToDisk(Archive archive, String outputPath, {bool asyncWrite = false, int? bufferSize})
``` 
to
```dart
Future<void> extractArchiveToDisk(Archive archive,String outputPath, {int? bufferSize,}) async{}
```
Releated:
- https://github.com/rainyl/opencv_dart/pull/42
- https://github.com/rainyl/opencv_dart/issues/41