### PR TITLE
New API: Mat::ptr -> Mat.ptrAt

### DIFF
--- a/lib/src/core/base.dart
+++ b/lib/src/core/base.dart
@@ -100,6 +100,15 @@ typedef NativeFinalizerFunctionT<T extends ffi.NativeType>
 ffi.NativeFinalizer OcvFinalizer<T extends ffi.NativeType>(NativeFinalizerFunctionT<T> func) =>
     ffi.NativeFinalizer(func.cast<ffi.NativeFinalizerFunction>());
 
+typedef U8 = ffi.UnsignedChar;
+typedef I8 = ffi.Char;
+typedef U16 = ffi.UnsignedShort;
+typedef I16 = ffi.Short;
+// typedef U32 = ffi.UnsignedInt;
+typedef I32 = ffi.Int;
+typedef F32 = ffi.Float;
+typedef F64 = ffi.Double;
+
 enum ImageFormat {
   // Windows bitmaps - *.bmp, *.dib (always supported)
   bmp(ext: ".bmp"),

--- a/lib/src/core/mat.dart
+++ b/lib/src/core/mat.dart
@@ -577,7 +577,7 @@ class Mat extends CvStruct<cvg.Mat> {
   /// final mat = cv.Mat.ones(3, 3, cv.MatType.CV_8UC1);
   /// mat.set<int>(0, 0, 99);
   ///
-  /// final ptr = mat.ptrAt(0, 0);
+  /// final ptr = mat.ptrAt<cv.U8>(0, 0);
   /// print(ptr[0]); // 99
   ///
   /// ptr[0] = 21;
@@ -585,7 +585,7 @@ class Mat extends CvStruct<cvg.Mat> {
   /// print(mat.at<int>(0, 0)); // 21
   /// print(ptr[0]); // 21
   ///
-  /// final ptr1 = mat.ptrAt(0);
+  /// final ptr1 = mat.ptrAt<cv.U8>(0);
   /// print(ptr1[0]); // 21
   /// print(List.generate(mat.cols, (i)=>ptr1[i]); // [21, 1, 1]
   /// ```

--- a/lib/src/core/mat.dart
+++ b/lib/src/core/mat.dart
@@ -569,8 +569,10 @@ class Mat extends CvStruct<cvg.Mat> {
   bool isSubtype<S, T>() => <S>[] is List<T>;
 
   /// equivalent to Mat::ptr\<T\>(i0, i1, i2)
-  /// DANGEROUS!
-  /// returns a pointer, remember to free
+  ///
+  /// **DANGEROUS**
+  ///
+  /// returns a pointer to operate Mat directly and effectively, use with caution!
   ///
   /// Example:
   /// ```dart

--- a/lib/src/core/mat.dart
+++ b/lib/src/core/mat.dart
@@ -545,7 +545,7 @@ class Mat extends CvStruct<cvg.Mat> {
   }
 
   /// equivalent to Mat::at\<T\>(i0, i1, i2) = val;
-  /// where T might be basic value types like uchar, char, int.
+  /// where T might be int, double.
   /// or cv::Vec<> like cv::Vec3b
   ///
   /// example
@@ -567,6 +567,152 @@ class Mat extends CvStruct<cvg.Mat> {
 
   // https://github.com/dart-lang/sdk/issues/43390#issuecomment-690993957
   bool isSubtype<S, T>() => <S>[] is List<T>;
+
+  /// equivalent to Mat::ptr\<T\>(i0, i1, i2)
+  /// DANGEROUS!
+  /// returns a pointer, remember to free
+  ///
+  /// Example:
+  /// ```dart
+  /// final mat = cv.Mat.ones(3, 3, cv.MatType.CV_8UC1);
+  /// mat.set<int>(0, 0, 99);
+  ///
+  /// final ptr = mat.ptrAt(0, 0);
+  /// print(ptr[0]); // 99
+  ///
+  /// ptr[0] = 21;
+  /// // Mat::ptr(i, j)
+  /// print(mat.at<int>(0, 0)); // 21
+  /// print(ptr[0]); // 21
+  ///
+  /// final ptr1 = mat.ptrAt(0);
+  /// print(ptr1[0]); // 21
+  /// print(List.generate(mat.cols, (i)=>ptr1[i]); // [21, 1, 1]
+  /// ```
+  ///
+  /// https://docs.opencv.org/4.x/d3/d63/classcv_1_1Mat.html#a8b2912f6a6f5d55a3c9a7aae9134d862
+  ffi.Pointer<T> ptrAt<T extends ffi.NativeType>(int i0, [int? i1, int? i2]) {
+    if (T == ffi.UnsignedChar) return ptrU8(i0, i1, i2) as ffi.Pointer<T>;
+    if (T == ffi.Char) return ptrI8(i0, i1, i2) as ffi.Pointer<T>;
+    if (T == ffi.UnsignedShort) return ptrU16(i0, i1, i2) as ffi.Pointer<T>;
+    if (T == ffi.Short) return ptrI16(i0, i1, i2) as ffi.Pointer<T>;
+    if (T == ffi.Int) return ptrI32(i0, i1, i2) as ffi.Pointer<T>;
+    if (T == ffi.Float) return ptrF32(i0, i1, i2) as ffi.Pointer<T>;
+    if (T == ffi.Double) return ptrF64(i0, i1, i2) as ffi.Pointer<T>;
+    throw UnsupportedError("ptr<$T>() is not supported!");
+  }
+
+  ffi.Pointer<ffi.UnsignedChar> ptrU8(int i0, [int? i1, int? i2]) {
+    final p = calloc<ffi.Pointer<ffi.UnsignedChar>>();
+    if (i1 == null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_u8_1(ref, i0, p));
+    } else if (i1 != null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_u8_2(ref, i0, i1, p));
+    } else if (i1 != null && i2 != null) {
+      cvRun(() => CFFI.Mat_Ptr_u8_3(ref, i0, i1, i2, p));
+    } else {
+      throw UnsupportedError("ptrU8($i0, $i1, $i2) is not supported!");
+    }
+    final ret = p.value.cast<ffi.UnsignedChar>();
+    calloc.free(p);
+    return ret;
+  }
+
+  ffi.Pointer<ffi.Char> ptrI8(int i0, [int? i1, int? i2]) {
+    final p = calloc<ffi.Pointer<ffi.Char>>();
+    if (i1 == null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_i8_1(ref, i0, p));
+    } else if (i1 != null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_i8_2(ref, i0, i1, p));
+    } else if (i1 != null && i2 != null) {
+      cvRun(() => CFFI.Mat_Ptr_i8_3(ref, i0, i1, i2, p));
+    } else {
+      throw UnsupportedError("ptrI8($i0, $i1, $i2) is not supported!");
+    }
+    final ret = p.value.cast<ffi.Char>();
+    calloc.free(p);
+    return ret;
+  }
+
+  ffi.Pointer<ffi.UnsignedShort> ptrU16(int i0, [int? i1, int? i2]) {
+    final p = calloc<ffi.Pointer<ffi.UnsignedShort>>();
+    if (i1 == null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_u16_1(ref, i0, p));
+    } else if (i1 != null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_u16_2(ref, i0, i1, p));
+    } else if (i1 != null && i2 != null) {
+      cvRun(() => CFFI.Mat_Ptr_u16_3(ref, i0, i1, i2, p));
+    } else {
+      throw UnsupportedError("ptrU16($i0, $i1, $i2) is not supported!");
+    }
+    final ret = p.value.cast<ffi.UnsignedShort>();
+    calloc.free(p);
+    return ret;
+  }
+
+  ffi.Pointer<ffi.Short> ptrI16(int i0, [int? i1, int? i2]) {
+    final p = calloc<ffi.Pointer<ffi.Short>>();
+    if (i1 == null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_i16_1(ref, i0, p));
+    } else if (i1 != null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_i16_2(ref, i0, i1, p));
+    } else if (i1 != null && i2 != null) {
+      cvRun(() => CFFI.Mat_Ptr_i16_3(ref, i0, i1, i2, p));
+    } else {
+      throw UnsupportedError("ptrI16($i0, $i1, $i2) is not supported!");
+    }
+    final ret = p.value.cast<ffi.Short>();
+    calloc.free(p);
+    return ret;
+  }
+
+  ffi.Pointer<ffi.Int> ptrI32(int i0, [int? i1, int? i2]) {
+    final p = calloc<ffi.Pointer<ffi.Int>>();
+    if (i1 == null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_i32_1(ref, i0, p));
+    } else if (i1 != null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_i32_2(ref, i0, i1, p));
+    } else if (i1 != null && i2 != null) {
+      cvRun(() => CFFI.Mat_Ptr_i32_3(ref, i0, i1, i2, p));
+    } else {
+      throw UnsupportedError("ptrI32($i0, $i1, $i2) is not supported!");
+    }
+    final ret = p.value.cast<ffi.Int>();
+    calloc.free(p);
+    return ret;
+  }
+
+  ffi.Pointer<ffi.Float> ptrF32(int i0, [int? i1, int? i2]) {
+    final p = calloc<ffi.Pointer<ffi.Float>>();
+    if (i1 == null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_f32_1(ref, i0, p));
+    } else if (i1 != null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_f32_2(ref, i0, i1, p));
+    } else if (i1 != null && i2 != null) {
+      cvRun(() => CFFI.Mat_Ptr_f32_3(ref, i0, i1, i2, p));
+    } else {
+      throw UnsupportedError("ptrF32($i0, $i1, $i2) is not supported!");
+    }
+    final ret = p.value.cast<ffi.Float>();
+    calloc.free(p);
+    return ret;
+  }
+
+  ffi.Pointer<ffi.Double> ptrF64(int i0, [int? i1, int? i2]) {
+    final p = calloc<ffi.Pointer<ffi.Double>>();
+    if (i1 == null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_f64_1(ref, i0, p));
+    } else if (i1 != null && i2 == null) {
+      cvRun(() => CFFI.Mat_Ptr_f64_2(ref, i0, i1, p));
+    } else if (i1 != null && i2 != null) {
+      cvRun(() => CFFI.Mat_Ptr_f64_3(ref, i0, i1, i2, p));
+    } else {
+      throw UnsupportedError("ptrF64($i0, $i1, $i2) is not supported!");
+    }
+    final ret = p.value.cast<ffi.Double>();
+    calloc.free(p);
+    return ret;
+  }
 
   // TODO: for now, dart do not support operator overloading
   // https://github.com/dart-lang/language/issues/2456

--- a/lib/src/opencv.g.dart
+++ b/lib/src/opencv.g.dart
@@ -8902,6 +8902,453 @@ class CvNative {
   late final _Mat_Pow =
       _Mat_PowPtr.asFunction<CvStatus Function(Mat, double, Mat)>();
 
+  CvStatus Mat_Ptr_f32_1(
+    Mat m,
+    int i,
+    ffi.Pointer<ffi.Pointer<ffi.Float>> rval,
+  ) {
+    return _Mat_Ptr_f32_1(
+      m,
+      i,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_f32_1Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Float>>)>>('Mat_Ptr_f32_1');
+  late final _Mat_Ptr_f32_1 = _Mat_Ptr_f32_1Ptr.asFunction<
+      CvStatus Function(Mat, int, ffi.Pointer<ffi.Pointer<ffi.Float>>)>();
+
+  CvStatus Mat_Ptr_f32_2(
+    Mat m,
+    int i,
+    int j,
+    ffi.Pointer<ffi.Pointer<ffi.Float>> rval,
+  ) {
+    return _Mat_Ptr_f32_2(
+      m,
+      i,
+      j,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_f32_2Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Float>>)>>('Mat_Ptr_f32_2');
+  late final _Mat_Ptr_f32_2 = _Mat_Ptr_f32_2Ptr.asFunction<
+      CvStatus Function(Mat, int, int, ffi.Pointer<ffi.Pointer<ffi.Float>>)>();
+
+  CvStatus Mat_Ptr_f32_3(
+    Mat m,
+    int i,
+    int j,
+    int k,
+    ffi.Pointer<ffi.Pointer<ffi.Float>> rval,
+  ) {
+    return _Mat_Ptr_f32_3(
+      m,
+      i,
+      j,
+      k,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_f32_3Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Float>>)>>('Mat_Ptr_f32_3');
+  late final _Mat_Ptr_f32_3 = _Mat_Ptr_f32_3Ptr.asFunction<
+      CvStatus Function(
+          Mat, int, int, int, ffi.Pointer<ffi.Pointer<ffi.Float>>)>();
+
+  CvStatus Mat_Ptr_f64_1(
+    Mat m,
+    int i,
+    ffi.Pointer<ffi.Pointer<ffi.Double>> rval,
+  ) {
+    return _Mat_Ptr_f64_1(
+      m,
+      i,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_f64_1Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Double>>)>>('Mat_Ptr_f64_1');
+  late final _Mat_Ptr_f64_1 = _Mat_Ptr_f64_1Ptr.asFunction<
+      CvStatus Function(Mat, int, ffi.Pointer<ffi.Pointer<ffi.Double>>)>();
+
+  CvStatus Mat_Ptr_f64_2(
+    Mat m,
+    int i,
+    int j,
+    ffi.Pointer<ffi.Pointer<ffi.Double>> rval,
+  ) {
+    return _Mat_Ptr_f64_2(
+      m,
+      i,
+      j,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_f64_2Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Double>>)>>('Mat_Ptr_f64_2');
+  late final _Mat_Ptr_f64_2 = _Mat_Ptr_f64_2Ptr.asFunction<
+      CvStatus Function(Mat, int, int, ffi.Pointer<ffi.Pointer<ffi.Double>>)>();
+
+  CvStatus Mat_Ptr_f64_3(
+    Mat m,
+    int i,
+    int j,
+    int k,
+    ffi.Pointer<ffi.Pointer<ffi.Double>> rval,
+  ) {
+    return _Mat_Ptr_f64_3(
+      m,
+      i,
+      j,
+      k,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_f64_3Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Double>>)>>('Mat_Ptr_f64_3');
+  late final _Mat_Ptr_f64_3 = _Mat_Ptr_f64_3Ptr.asFunction<
+      CvStatus Function(
+          Mat, int, int, int, ffi.Pointer<ffi.Pointer<ffi.Double>>)>();
+
+  CvStatus Mat_Ptr_i16_1(
+    Mat m,
+    int i,
+    ffi.Pointer<ffi.Pointer<ffi.Short>> rval,
+  ) {
+    return _Mat_Ptr_i16_1(
+      m,
+      i,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i16_1Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Short>>)>>('Mat_Ptr_i16_1');
+  late final _Mat_Ptr_i16_1 = _Mat_Ptr_i16_1Ptr.asFunction<
+      CvStatus Function(Mat, int, ffi.Pointer<ffi.Pointer<ffi.Short>>)>();
+
+  CvStatus Mat_Ptr_i16_2(
+    Mat m,
+    int i,
+    int j,
+    ffi.Pointer<ffi.Pointer<ffi.Short>> rval,
+  ) {
+    return _Mat_Ptr_i16_2(
+      m,
+      i,
+      j,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i16_2Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Short>>)>>('Mat_Ptr_i16_2');
+  late final _Mat_Ptr_i16_2 = _Mat_Ptr_i16_2Ptr.asFunction<
+      CvStatus Function(Mat, int, int, ffi.Pointer<ffi.Pointer<ffi.Short>>)>();
+
+  CvStatus Mat_Ptr_i16_3(
+    Mat m,
+    int i,
+    int j,
+    int k,
+    ffi.Pointer<ffi.Pointer<ffi.Short>> rval,
+  ) {
+    return _Mat_Ptr_i16_3(
+      m,
+      i,
+      j,
+      k,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i16_3Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Short>>)>>('Mat_Ptr_i16_3');
+  late final _Mat_Ptr_i16_3 = _Mat_Ptr_i16_3Ptr.asFunction<
+      CvStatus Function(
+          Mat, int, int, int, ffi.Pointer<ffi.Pointer<ffi.Short>>)>();
+
+  CvStatus Mat_Ptr_i32_1(
+    Mat m,
+    int i,
+    ffi.Pointer<ffi.Pointer<ffi.Int>> rval,
+  ) {
+    return _Mat_Ptr_i32_1(
+      m,
+      i,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i32_1Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Int>>)>>('Mat_Ptr_i32_1');
+  late final _Mat_Ptr_i32_1 = _Mat_Ptr_i32_1Ptr.asFunction<
+      CvStatus Function(Mat, int, ffi.Pointer<ffi.Pointer<ffi.Int>>)>();
+
+  CvStatus Mat_Ptr_i32_2(
+    Mat m,
+    int i,
+    int j,
+    ffi.Pointer<ffi.Pointer<ffi.Int>> rval,
+  ) {
+    return _Mat_Ptr_i32_2(
+      m,
+      i,
+      j,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i32_2Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Int>>)>>('Mat_Ptr_i32_2');
+  late final _Mat_Ptr_i32_2 = _Mat_Ptr_i32_2Ptr.asFunction<
+      CvStatus Function(Mat, int, int, ffi.Pointer<ffi.Pointer<ffi.Int>>)>();
+
+  CvStatus Mat_Ptr_i32_3(
+    Mat m,
+    int i,
+    int j,
+    int k,
+    ffi.Pointer<ffi.Pointer<ffi.Int>> rval,
+  ) {
+    return _Mat_Ptr_i32_3(
+      m,
+      i,
+      j,
+      k,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i32_3Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Int>>)>>('Mat_Ptr_i32_3');
+  late final _Mat_Ptr_i32_3 = _Mat_Ptr_i32_3Ptr.asFunction<
+      CvStatus Function(
+          Mat, int, int, int, ffi.Pointer<ffi.Pointer<ffi.Int>>)>();
+
+  CvStatus Mat_Ptr_i8_1(
+    Mat m,
+    int i,
+    ffi.Pointer<ffi.Pointer<ffi.Char>> rval,
+  ) {
+    return _Mat_Ptr_i8_1(
+      m,
+      i,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i8_1Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('Mat_Ptr_i8_1');
+  late final _Mat_Ptr_i8_1 = _Mat_Ptr_i8_1Ptr.asFunction<
+      CvStatus Function(Mat, int, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+
+  CvStatus Mat_Ptr_i8_2(
+    Mat m,
+    int i,
+    int j,
+    ffi.Pointer<ffi.Pointer<ffi.Char>> rval,
+  ) {
+    return _Mat_Ptr_i8_2(
+      m,
+      i,
+      j,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i8_2Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('Mat_Ptr_i8_2');
+  late final _Mat_Ptr_i8_2 = _Mat_Ptr_i8_2Ptr.asFunction<
+      CvStatus Function(Mat, int, int, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+
+  CvStatus Mat_Ptr_i8_3(
+    Mat m,
+    int i,
+    int j,
+    int k,
+    ffi.Pointer<ffi.Pointer<ffi.Char>> rval,
+  ) {
+    return _Mat_Ptr_i8_3(
+      m,
+      i,
+      j,
+      k,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_i8_3Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('Mat_Ptr_i8_3');
+  late final _Mat_Ptr_i8_3 = _Mat_Ptr_i8_3Ptr.asFunction<
+      CvStatus Function(
+          Mat, int, int, int, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+
+  CvStatus Mat_Ptr_u16_1(
+    Mat m,
+    int i,
+    ffi.Pointer<ffi.Pointer<ushort>> rval,
+  ) {
+    return _Mat_Ptr_u16_1(
+      m,
+      i,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_u16_1Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ushort>>)>>('Mat_Ptr_u16_1');
+  late final _Mat_Ptr_u16_1 = _Mat_Ptr_u16_1Ptr.asFunction<
+      CvStatus Function(Mat, int, ffi.Pointer<ffi.Pointer<ushort>>)>();
+
+  CvStatus Mat_Ptr_u16_2(
+    Mat m,
+    int i,
+    int j,
+    ffi.Pointer<ffi.Pointer<ushort>> rval,
+  ) {
+    return _Mat_Ptr_u16_2(
+      m,
+      i,
+      j,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_u16_2Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ushort>>)>>('Mat_Ptr_u16_2');
+  late final _Mat_Ptr_u16_2 = _Mat_Ptr_u16_2Ptr.asFunction<
+      CvStatus Function(Mat, int, int, ffi.Pointer<ffi.Pointer<ushort>>)>();
+
+  CvStatus Mat_Ptr_u16_3(
+    Mat m,
+    int i,
+    int j,
+    int k,
+    ffi.Pointer<ffi.Pointer<ushort>> rval,
+  ) {
+    return _Mat_Ptr_u16_3(
+      m,
+      i,
+      j,
+      k,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_u16_3Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<ushort>>)>>('Mat_Ptr_u16_3');
+  late final _Mat_Ptr_u16_3 = _Mat_Ptr_u16_3Ptr.asFunction<
+      CvStatus Function(
+          Mat, int, int, int, ffi.Pointer<ffi.Pointer<ushort>>)>();
+
+  CvStatus Mat_Ptr_u8_1(
+    Mat m,
+    int i,
+    ffi.Pointer<ffi.Pointer<uchar>> rval,
+  ) {
+    return _Mat_Ptr_u8_1(
+      m,
+      i,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_u8_1Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(
+              Mat, ffi.Int, ffi.Pointer<ffi.Pointer<uchar>>)>>('Mat_Ptr_u8_1');
+  late final _Mat_Ptr_u8_1 = _Mat_Ptr_u8_1Ptr.asFunction<
+      CvStatus Function(Mat, int, ffi.Pointer<ffi.Pointer<uchar>>)>();
+
+  CvStatus Mat_Ptr_u8_2(
+    Mat m,
+    int i,
+    int j,
+    ffi.Pointer<ffi.Pointer<uchar>> rval,
+  ) {
+    return _Mat_Ptr_u8_2(
+      m,
+      i,
+      j,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_u8_2Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<uchar>>)>>('Mat_Ptr_u8_2');
+  late final _Mat_Ptr_u8_2 = _Mat_Ptr_u8_2Ptr.asFunction<
+      CvStatus Function(Mat, int, int, ffi.Pointer<ffi.Pointer<uchar>>)>();
+
+  CvStatus Mat_Ptr_u8_3(
+    Mat m,
+    int i,
+    int j,
+    int k,
+    ffi.Pointer<ffi.Pointer<uchar>> rval,
+  ) {
+    return _Mat_Ptr_u8_3(
+      m,
+      i,
+      j,
+      k,
+      rval,
+    );
+  }
+
+  late final _Mat_Ptr_u8_3Ptr = _lookup<
+      ffi.NativeFunction<
+          CvStatus Function(Mat, ffi.Int, ffi.Int, ffi.Int,
+              ffi.Pointer<ffi.Pointer<uchar>>)>>('Mat_Ptr_u8_3');
+  late final _Mat_Ptr_u8_3 = _Mat_Ptr_u8_3Ptr.asFunction<
+      CvStatus Function(Mat, int, int, int, ffi.Pointer<ffi.Pointer<uchar>>)>();
+
   CvStatus Mat_Reduce(
     Mat src,
     Mat dst,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
   archive: ^3.5.1
 
 dev_dependencies:
-  ffigen: ^11.0.0
+  ffigen: ^12.0.0
   flutter_lints: ^4.0.0
-  test: ^1.25.5
+  test: ^1.25.2
 
 topics:
   - opencv

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opencv_dart
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 1.0.2+2
-binary_version: 1.0.2
+version: 1.0.3
+binary_version: 1.0.3
 homepage: https://github.com/rainyl/opencv_dart
 
 environment:

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -348,6 +348,136 @@ CvStatus Ones(int rows, int cols, int type, Mat *rval)
   END_WRAP
 }
 
+CvStatus Mat_Ptr_u8_1(Mat m, int i, uchar **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr(i);
+  END_WRAP
+}
+
+CvStatus Mat_Ptr_u8_2(Mat m, int i, int j, uchar **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr(i, j);
+  END_WRAP
+}
+
+CvStatus Mat_Ptr_u8_3(Mat m, int i, int j, int k, uchar **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr(i, j, k);
+  END_WRAP
+}
+
+CvStatus Mat_Ptr_i8_1(Mat m, int i, char **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<char>(i);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i8_2(Mat m, int i, int j, char **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<char>(i, j);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i8_3(Mat m, int i, int j, int k, char **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<char>(i, j, k);
+  END_WRAP
+}
+CvStatus Mat_Ptr_u16_1(Mat m, int i, ushort **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<ushort>(i);
+  END_WRAP
+}
+CvStatus Mat_Ptr_u16_2(Mat m, int i, int j, ushort **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<ushort>(i, j);
+  END_WRAP
+}
+CvStatus Mat_Ptr_u16_3(Mat m, int i, int j, int k, ushort **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<ushort>(i, j, k);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i16_1(Mat m, int i, short **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<short>(i);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i16_2(Mat m, int i, int j, short **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<short>(i, j);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i16_3(Mat m, int i, int j, int k, short **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<short>(i, j, k);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i32_1(Mat m, int i, int **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<int>(i);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i32_2(Mat m, int i, int j, int **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<int>(i, j);
+  END_WRAP
+}
+CvStatus Mat_Ptr_i32_3(Mat m, int i, int j, int k, int **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<int>(i, j, k);
+  END_WRAP
+}
+CvStatus Mat_Ptr_f32_1(Mat m, int i, float **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<float>(i);
+  END_WRAP
+}
+CvStatus Mat_Ptr_f32_2(Mat m, int i, int j, float **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<float>(i, j);
+  END_WRAP
+}
+CvStatus Mat_Ptr_f32_3(Mat m, int i, int j, int k, float **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<float>(i, j, k);
+  END_WRAP
+}
+CvStatus Mat_Ptr_f64_1(Mat m, int i, double **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<double>(i);
+  END_WRAP
+}
+CvStatus Mat_Ptr_f64_2(Mat m, int i, int j, double **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<double>(i, j);
+  END_WRAP
+}
+CvStatus Mat_Ptr_f64_3(Mat m, int i, int j, int k, double **rval)
+{
+  BEGIN_WRAP
+  *rval = m.ptr->ptr<double>(i, j, k);
+  END_WRAP
+}
+
 #pragma region Mat_getter
 
 CvStatus Mat_GetUChar(Mat m, int row, int col, uint8_t *rval)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -471,6 +471,28 @@ CvStatus Eye(int rows, int cols, int type, Mat *rval);
 CvStatus Zeros(int rows, int cols, int type, Mat *rval);
 CvStatus Ones(int rows, int cols, int type, Mat *rval);
 
+CvStatus Mat_Ptr_u8_1(Mat m, int i, uchar **rval);
+CvStatus Mat_Ptr_u8_2(Mat m, int i, int j, uchar **rval);
+CvStatus Mat_Ptr_u8_3(Mat m, int i, int j, int k, uchar **rval);
+CvStatus Mat_Ptr_i8_1(Mat m, int i, char **rval);
+CvStatus Mat_Ptr_i8_2(Mat m, int i, int j, char **rval);
+CvStatus Mat_Ptr_i8_3(Mat m, int i, int j, int k, char **rval);
+CvStatus Mat_Ptr_u16_1(Mat m, int i, ushort **rval);
+CvStatus Mat_Ptr_u16_2(Mat m, int i, int j, ushort **rval);
+CvStatus Mat_Ptr_u16_3(Mat m, int i, int j, int k, ushort **rval);
+CvStatus Mat_Ptr_i16_1(Mat m, int i, short **rval);
+CvStatus Mat_Ptr_i16_2(Mat m, int i, int j, short **rval);
+CvStatus Mat_Ptr_i16_3(Mat m, int i, int j, int k, short **rval);
+CvStatus Mat_Ptr_i32_1(Mat m, int i, int **rval);
+CvStatus Mat_Ptr_i32_2(Mat m, int i, int j, int **rval);
+CvStatus Mat_Ptr_i32_3(Mat m, int i, int j, int k, int **rval);
+CvStatus Mat_Ptr_f32_1(Mat m, int i, float **rval);
+CvStatus Mat_Ptr_f32_2(Mat m, int i, int j, float **rval);
+CvStatus Mat_Ptr_f32_3(Mat m, int i, int j, int k, float **rval);
+CvStatus Mat_Ptr_f64_1(Mat m, int i, double **rval);
+CvStatus Mat_Ptr_f64_2(Mat m, int i, int j, double **rval);
+CvStatus Mat_Ptr_f64_3(Mat m, int i, int j, int k, double **rval);
+
 #pragma region Mat_getter
 
 CvStatus Mat_GetUChar(Mat m, int row, int col, uint8_t *rval);

--- a/test/core/mat_test.dart
+++ b/test/core/mat_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi' as ffi;
+
 import 'package:test/test.dart';
 import 'package:opencv_dart/opencv_dart.dart' as cv;
 
@@ -272,6 +274,34 @@ void main() async {
     final matG = cv.extractChannel(mat0, 1);
     final meanG = matG.mean();
     expect(meanG.val1, equals(1));
+  });
+
+  test('Mat.ptrAt', () {
+    final mat = cv.Mat.ones(3, 3, cv.MatType.CV_8UC1);
+    mat.set<int>(0, 0, 99);
+
+    final ptr = mat.ptrU8(0, 0);
+    expect(ptr.address, greaterThan(0));
+    expect(ptr[0], 99);
+
+    ptr[0] = 21;
+    expect(mat.at<int>(0, 0), 21);
+    expect(ptr[0], 21);
+    final ptr1 = mat.ptrU8(0);
+    expect(ptr1.address, greaterThan(0));
+    expect(ptr1[0], 21);
+    expect(List.generate(mat.cols, (i)=>ptr1[i]), [21, 1, 1]);
+
+    final mat1 = mat.convertTo(cv.MatType.CV_32FC1);
+    mat1.set<double>(0, 0, 99.0);
+    expect(mat1.at<double>(0, 0), 99.0);
+    final ptr2 = mat1.ptrF32(0);
+    expect(ptr2.address, greaterThan(0));
+    expect(ptr2[0], 99.0);
+    expect(List.generate(mat1.cols, (i)=>ptr2[i]), [99.0, 1.0, 1.0]);
+
+    ptr2[1] = 241.0;
+    expect(List.generate(mat1.cols, (i)=>ptr2[i]), [99.0, 241.0, 1.0]);
   });
 
   test('Mat At Set Vec*b(uchar)', () {

--- a/test/core/mat_test.dart
+++ b/test/core/mat_test.dart
@@ -363,7 +363,9 @@ void main() async {
     final ptr1 = mat.ptrAt<cv.F32>(0, 0);
     expect(ptr1.address, greaterThan(0));
     expect(ptr1[0], closeTo(21.0, 1e-6));
-    expect(List.generate(mat.cols, (i) => ptr1[i]), [21.0, 1.0, 1.0]);
+    final expected = [21.0, 1.0, 1.0];
+    final accessed = List.generate(mat.cols, (i) => ptr1[i]);
+    expect(expected.indexed.map((e) => e.$2 - accessed[e.$1] < 1e-6).every((e) => e), true);
   });
 
   test('Mat.ptrAt.F64', () {
@@ -378,7 +380,9 @@ void main() async {
     final ptr1 = mat.ptrAt<cv.F64>(0, 0);
     expect(ptr1.address, greaterThan(0));
     expect(ptr1[0], closeTo(21.0, 1e-6));
-    expect(List.generate(mat.cols, (i) => ptr1[i]), [21.0, 1.0, 1.0]);
+    final expected = [21.0, 1.0, 1.0];
+    final accessed = List.generate(mat.cols, (i) => ptr1[i]);
+    expect(expected.indexed.map((e) => e.$2 - accessed[e.$1] < 1e-6).every((e) => e), true);
   });
 
   test('Mat At Set Vec*b(uchar)', () {

--- a/test/core/mat_test.dart
+++ b/test/core/mat_test.dart
@@ -276,32 +276,109 @@ void main() async {
     expect(meanG.val1, equals(1));
   });
 
-  test('Mat.ptrAt', () {
+  test('Mat.ptrAt.U8', () {
     final mat = cv.Mat.ones(3, 3, cv.MatType.CV_8UC1);
-    mat.set<int>(0, 0, 99);
-
-    final ptr = mat.ptrU8(0, 0);
-    expect(ptr.address, greaterThan(0));
-    expect(ptr[0], 99);
-
-    ptr[0] = 21;
+    final ptr0 = mat.ptrAt<cv.U8>(0);
+    expect(ptr0.address, greaterThan(0));
+    expect(ptr0[0], 1);
+    ptr0[0] = 21;
     expect(mat.at<int>(0, 0), 21);
-    expect(ptr[0], 21);
-    final ptr1 = mat.ptrU8(0);
+    expect(ptr0[0], 21);
+
+    final ptr1 = mat.ptrAt<cv.U8>(0, 0);
     expect(ptr1.address, greaterThan(0));
     expect(ptr1[0], 21);
-    expect(List.generate(mat.cols, (i)=>ptr1[i]), [21, 1, 1]);
+    expect(List.generate(mat.cols, (i) => ptr1[i]), [21, 1, 1]);
+  });
 
-    final mat1 = mat.convertTo(cv.MatType.CV_32FC1);
-    mat1.set<double>(0, 0, 99.0);
-    expect(mat1.at<double>(0, 0), 99.0);
-    final ptr2 = mat1.ptrF32(0);
-    expect(ptr2.address, greaterThan(0));
-    expect(ptr2[0], 99.0);
-    expect(List.generate(mat1.cols, (i)=>ptr2[i]), [99.0, 1.0, 1.0]);
+  test('Mat.ptrAt.I8', () {
+    final mat = cv.Mat.ones(3, 3, cv.MatType.CV_8SC1);
+    final ptr0 = mat.ptrAt<cv.I8>(0);
+    expect(ptr0.address, greaterThan(0));
+    expect(ptr0[0], 1);
+    ptr0[0] = 21;
+    expect(mat.at<int>(0, 0), 21);
+    expect(ptr0[0], 21);
 
-    ptr2[1] = 241.0;
-    expect(List.generate(mat1.cols, (i)=>ptr2[i]), [99.0, 241.0, 1.0]);
+    final ptr1 = mat.ptrAt<cv.I8>(0, 0);
+    expect(ptr1.address, greaterThan(0));
+    expect(ptr1[0], 21);
+    expect(List.generate(mat.cols, (i) => ptr1[i]), [21, 1, 1]);
+  });
+
+  test('Mat.ptrAt.U16', () {
+    final mat = cv.Mat.ones(3, 3, cv.MatType.CV_16UC1);
+    final ptr0 = mat.ptrAt<cv.U16>(0);
+    expect(ptr0.address, greaterThan(0));
+    expect(ptr0[0], 1);
+    ptr0[0] = 21;
+    expect(mat.at<int>(0, 0), 21);
+    expect(ptr0[0], 21);
+
+    final ptr1 = mat.ptrAt<cv.U16>(0, 0);
+    expect(ptr1.address, greaterThan(0));
+    expect(ptr1[0], 21);
+    expect(List.generate(mat.cols, (i) => ptr1[i]), [21, 1, 1]);
+  });
+
+  test('Mat.ptrAt.I16', () {
+    final mat = cv.Mat.ones(3, 3, cv.MatType.CV_16SC1);
+    final ptr0 = mat.ptrAt<cv.I16>(0);
+    expect(ptr0.address, greaterThan(0));
+    expect(ptr0[0], 1);
+    ptr0[0] = 21;
+    expect(mat.at<int>(0, 0), 21);
+    expect(ptr0[0], 21);
+
+    final ptr1 = mat.ptrAt<cv.I16>(0, 0);
+    expect(ptr1.address, greaterThan(0));
+    expect(ptr1[0], 21);
+    expect(List.generate(mat.cols, (i) => ptr1[i]), [21, 1, 1]);
+  });
+
+  test('Mat.ptrAt.I32', () {
+    final mat = cv.Mat.ones(3, 3, cv.MatType.CV_32SC1);
+    final ptr0 = mat.ptrAt<cv.I32>(0);
+    expect(ptr0.address, greaterThan(0));
+    expect(ptr0[0], 1);
+    ptr0[0] = 21;
+    expect(mat.at<int>(0, 0), 21);
+    expect(ptr0[0], 21);
+
+    final ptr1 = mat.ptrAt<cv.I32>(0, 0);
+    expect(ptr1.address, greaterThan(0));
+    expect(ptr1[0], 21);
+    expect(List.generate(mat.cols, (i) => ptr1[i]), [21, 1, 1]);
+  });
+
+  test('Mat.ptrAt.F32', () {
+    final mat = cv.Mat.ones(3, 3, cv.MatType.CV_32FC1);
+    final ptr0 = mat.ptrAt<cv.F32>(0);
+    expect(ptr0.address, greaterThan(0));
+    expect(ptr0[0], closeTo(1.0, 1e-6));
+    ptr0[0] = 21.0;
+    expect(mat.at<double>(0, 0), closeTo(21.0, 1e-6));
+    expect(ptr0[0], closeTo(21.0, 1e-6));
+
+    final ptr1 = mat.ptrAt<cv.F32>(0, 0);
+    expect(ptr1.address, greaterThan(0));
+    expect(ptr1[0], closeTo(21.0, 1e-6));
+    expect(List.generate(mat.cols, (i) => ptr1[i]), [21.0, 1.0, 1.0]);
+  });
+
+  test('Mat.ptrAt.F64', () {
+    final mat = cv.Mat.ones(3, 3, cv.MatType.CV_64FC1);
+    final ptr0 = mat.ptrAt<cv.F64>(0);
+    expect(ptr0.address, greaterThan(0));
+    expect(ptr0[0], closeTo(1.0, 1e-6));
+    ptr0[0] = 21.0;
+    expect(mat.at<double>(0, 0), closeTo(21.0, 1e-6));
+    expect(ptr0[0], closeTo(21.0, 1e-6));
+
+    final ptr1 = mat.ptrAt<cv.F64>(0, 0);
+    expect(ptr1.address, greaterThan(0));
+    expect(ptr1[0], closeTo(21.0, 1e-6));
+    expect(List.generate(mat.cols, (i) => ptr1[i]), [21.0, 1.0, 1.0]);
   });
 
   test('Mat At Set Vec*b(uchar)', () {


### PR DESCRIPTION
Add `Mat.ptrAt<T>(int i0, [int? i1, int? i2])` to access data pointer like Mat::ptr<T> https://docs.opencv.org/4.x/d3/d63/classcv_1_1Mat.html#a8b2912f6a6f5d55a3c9a7aae9134d862

New API:
- `ffi.Pointer<T> Mat.ptrAt<T extends ffi.NativeType>(int i0, [int? i1, int? i2])`
- `ffi.Pointer<ffi.UnsignedChar> Mat.ptrU8(int i0, [int? i1, int? i2])`
- `ffi.Pointer<ffi.Char> ptrI8(int i0, [int? i1, int? i2])`
- `ffi.Pointer<ffi.UnsignedShort> ptrU16(int i0, [int? i1, int? i2])`
- `ffi.Pointer<ffi.Short> ptrI16(int i0, [int? i1, int? i2])`
- `ffi.Pointer<ffi.Int> ptrI32(int i0, [int? i1, int? i2])`
- `ffi.Pointer<ffi.Float> ptrF32(int i0, [int? i1, int? i2])`
- `ffi.Pointer<ffi.Double> ptrF64(int i0, [int? i1, int? i2])`