### PR TITLE
Revert to 3.19.6 due to coverage wont exit

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "stable"
+  "flutter": "3.19.6"
 }

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -40,7 +40,7 @@ jobs:
           name: libopencv_dart-windows-x64.tar.gz
       - uses: subosito/flutter-action@v2
         with:
-          # flutter-version: '3.16.9'
+          flutter-version: '3.19.6'
           channel: "stable"
       - name: setup coverage
         run: |


### PR DESCRIPTION
coverage:test_with_coverage wonn't exit correctly on Flutter 3.22.0 so the test workflow fails.

[![build and test](https://github.com/rainyl/opencv_dart/actions/workflows/build_test.yaml/badge.svg)](https://github.com/rainyl/opencv_dart/actions/workflows/build_test.yaml)

Releated:
- https://github.com/dart-lang/coverage/issues/489