### PR TITLE
Improve the performance of at and set, add Mat.atU8, Mat.setU8, etc.

### DIFF
--- a/lib/src/core/mat.dart
+++ b/lib/src/core/mat.dart
@@ -237,72 +237,81 @@ class Mat extends CvStruct<cvg.Mat> {
     });
   }
 
-  T _atNum<T>(int row, int col, [int? cn]) {
-    return cvRunArena<T>((arena) {
-      switch (type.depth) {
-        case MatType.CV_8U:
-          final p = arena<ffi.Uint8>();
-          if (type.channels == 1 || cn == null) {
-            cvRun(() => CFFI.Mat_GetUChar(ref, row, col, p));
-          } else {
-            cvRun(() => CFFI.Mat_GetUChar3(ref, row, col, cn, p));
-          }
-          return p.value as T;
-        case MatType.CV_8S:
-          final p = arena<ffi.Int8>();
-          if (type.channels == 1 || cn == null) {
-            cvRun(() => CFFI.Mat_GetSChar(ref, row, col, p));
-          } else {
-            cvRun(() => CFFI.Mat_GetSChar3(ref, row, col, cn, p));
-          }
-          return p.value as T;
-        case MatType.CV_16U:
-          final p = arena<ffi.Uint16>();
-          if (type.channels == 1 || cn == null) {
-            cvRun(() => CFFI.Mat_GetUShort(ref, row, col, p));
-          } else {
-            cvRun(() => CFFI.Mat_GetUShort3(ref, row, col, cn, p));
-          }
-          return p.value as T;
-        case MatType.CV_16S:
-          final p = arena<ffi.Int16>();
-          if (type.channels == 1 || cn == null) {
-            cvRun(() => CFFI.Mat_GetShort(ref, row, col, p));
-          } else {
-            cvRun(() => CFFI.Mat_GetShort3(ref, row, col, cn, p));
-          }
-          return p.value as T;
-        case MatType.CV_32S:
-          final p = arena<ffi.Int32>();
-          if (type.channels == 1 || cn == null) {
-            cvRun(() => CFFI.Mat_GetInt(ref, row, col, p));
-          } else {
-            cvRun(() => CFFI.Mat_GetInt3(ref, row, col, cn, p));
-          }
-          return p.value as T;
-        case MatType.CV_32F:
-          final p = arena<ffi.Float>();
-          if (type.channels == 1 || cn == null) {
-            cvRun(() => CFFI.Mat_GetFloat(ref, row, col, p));
-          } else {
-            cvRun(() => CFFI.Mat_GetFloat3(ref, row, col, cn, p));
-          }
-          return p.value as T;
-        case MatType.CV_64F:
-          final p = arena<ffi.Double>();
-          if (type.channels == 1 || cn == null) {
-            cvRun(() => CFFI.Mat_GetDouble(ref, row, col, p));
-          } else {
-            cvRun(() => CFFI.Mat_GetDouble3(ref, row, col, cn, p));
-          }
-          return p.value as T;
-        default:
-          throw UnsupportedError("at() for $type is not supported!");
-      }
+  int atU8(int row, int col, [int? i2]) => using<int>((arena) {
+        final p = arena<ffi.Uint8>();
+        i2 == null
+            ? cvRun(() => CFFI.Mat_GetUChar(ref, row, col, p))
+            : cvRun(() => CFFI.Mat_GetUChar3(ref, row, col, i2, p));
+        return p.value;
+      });
+
+  int atI8(int row, int col, [int? i2]) => using<int>((arena) {
+        final p = arena<ffi.Int8>();
+        i2 == null
+            ? cvRun(() => CFFI.Mat_GetSChar(ref, row, col, p))
+            : cvRun(() => CFFI.Mat_GetSChar3(ref, row, col, i2, p));
+        return p.value;
+      });
+
+  int atU16(int row, int col, [int? i2]) => using<int>((arena) {
+        final p = arena<ffi.Uint16>();
+        i2 == null
+            ? cvRun(() => CFFI.Mat_GetUShort(ref, row, col, p))
+            : cvRun(() => CFFI.Mat_GetUShort3(ref, row, col, i2, p));
+        return p.value;
+      });
+
+  int atI16(int row, int col, [int? i2]) => using<int>((arena) {
+        final p = arena<ffi.Int16>();
+        i2 == null
+            ? cvRun(() => CFFI.Mat_GetShort(ref, row, col, p))
+            : cvRun(() => CFFI.Mat_GetShort3(ref, row, col, i2, p));
+        return p.value;
+      });
+
+  int atI32(int row, int col, [int? i2]) => using<int>((arena) {
+        final p = arena<ffi.Int32>();
+        i2 == null
+            ? cvRun(() => CFFI.Mat_GetInt(ref, row, col, p))
+            : cvRun(() => CFFI.Mat_GetInt3(ref, row, col, i2, p));
+        return p.value;
+      });
+
+  double atF32(int row, int col, [int? i2]) => using<double>((arena) {
+        final p = arena<ffi.Float>();
+        i2 == null
+            ? cvRun(() => CFFI.Mat_GetFloat(ref, row, col, p))
+            : cvRun(() => CFFI.Mat_GetFloat3(ref, row, col, i2, p));
+        return p.value;
+      });
+
+  double atF64(int row, int col, [int? i2]) => using<double>((arena) {
+        final p = arena<ffi.Double>();
+        i2 == null
+            ? cvRun(() => CFFI.Mat_GetDouble(ref, row, col, p))
+            : cvRun(() => CFFI.Mat_GetDouble3(ref, row, col, i2, p));
+        return p.value;
+      });
+
+  num atNum<T extends num>(int row, int col, [int? i2]) {
+    return using<num>((arena) {
+      final p = arena<ffi.Int>();
+      cvRun(() => CFFI.Mat_Type(ref, p));
+      final depth = p.value & (MatType.CV_DEPTH_MAX - 1);
+      return switch (depth) {
+        MatType.CV_8U => atU8(row, col, i2),
+        MatType.CV_8S => atI8(row, col, i2),
+        MatType.CV_16U => atU16(row, col, i2),
+        MatType.CV_16S => atI16(row, col, i2),
+        MatType.CV_32S => atI32(row, col, i2),
+        MatType.CV_32F => atF32(row, col, i2),
+        MatType.CV_64F => atF64(row, col, i2),
+        _ => throw UnsupportedError("Unsupported type: $type")
+      };
     });
   }
 
-  T _atVec<T>(int row, int col) {
+  T atVec<T>(int row, int col) {
     final v = cvRunArena<T>((arena) {
       // Vec2b, Vec3b, Vec4b
       if (T == Vec2b) {
@@ -412,76 +421,25 @@ class Mat extends CvStruct<cvg.Mat> {
 
   /// cv::Mat::at\<T\>(i0, i1, i2) of cv::Mat
   ///
-  ///
-  /// - If matrix is of type [MatType.CV_8U] then use Mat.at\<uchar\>(y,x).
-  /// - If matrix is of type [MatType.CV_8S] then use Mat.at\<schar\>(y,x).
-  /// - If matrix is of type [MatType.CV_16U] then use Mat.at\<ushort\>(y,x).
-  /// - If matrix is of type [MatType.CV_16S] then use Mat.at\<short\>(y,x).
-  /// - If matrix is of type [MatType.CV_32S] then use Mat.at\<int\>(y,x).
-  /// - If matrix is of type [MatType.CV_32F] then use Mat.at\<float\>(y,x).
-  /// - If matrix is of type [MatType.CV_64F] then use Mat.at\<double\>(y,x).
-  ///
   /// example:
   /// ```dart
   /// var m = cv.Mat.fromScalar(cv.Scalar(2, 4, 1, 0), cv.MatType.CV_32FC3);
-  /// m.at<double>(0, 0); // 2
+  /// m.at<double>(0, 0); // 2.0
   /// m.at<cv.Vec3f>(0, 0); // cv.Vec3f(2, 4, 1)
   /// ```
   ///
   /// https://docs.opencv.org/4.x/d3/d63/classcv_1_1Mat.html#a7a6d7e3696b8b19b9dfac3f209118c40
   T at<T>(int row, int col, [int? i2]) {
     if (T == int || T == double) {
-      return _atNum<T>(row, col, i2);
+      return atNum(row, col, i2) as T;
     } else if (isSubtype<T, CvVec>()) {
-      return _atVec<T>(row, col);
+      return atVec<T>(row, col);
     } else {
       throw UnsupportedError("T must be num or CvVec(e.g., Vec3b), but got $T");
     }
   }
 
-  void _setNum<T>(row, col, T val, [int? i2]) {
-    switch (type.depth) {
-      case MatType.CV_8U:
-        assert(T == int, "$type only support int");
-        type.channels == 1 || i2 == null
-            ? cvRun(() => CFFI.Mat_SetUChar(ref, row, col, val as int))
-            : cvRun(() => CFFI.Mat_SetUChar3(ref, row, col, i2, val as int));
-      case MatType.CV_8S:
-        assert(T == int, "$type only support int");
-        type.channels == 1 || i2 == null
-            ? cvRun(() => CFFI.Mat_SetSChar(ref, row, col, val as int))
-            : cvRun(() => CFFI.Mat_SetSChar3(ref, row, col, i2, val as int));
-      case MatType.CV_16U:
-        assert(T == int, "$type only support int");
-        type.channels == 1 || i2 == null
-            ? cvRun(() => CFFI.Mat_SetUShort(ref, row, col, val as int))
-            : cvRun(() => CFFI.Mat_SetUShort3(ref, row, col, i2, val as int));
-      case MatType.CV_16S:
-        assert(T == int, "$type only support int");
-        type.channels == 1 || i2 == null
-            ? cvRun(() => CFFI.Mat_SetShort(ref, row, col, val as int))
-            : cvRun(() => CFFI.Mat_SetShort3(ref, row, col, i2, val as int));
-      case MatType.CV_32S:
-        assert(T == int, "$type only support int");
-        type.channels == 1 || i2 == null
-            ? cvRun(() => CFFI.Mat_SetInt(ref, row, col, val as int))
-            : cvRun(() => CFFI.Mat_SetInt3(ref, row, col, i2, val as int));
-      case MatType.CV_32F:
-        assert(T == double, "$type only support double");
-        type.channels == 1 || i2 == null
-            ? cvRun(() => CFFI.Mat_SetFloat(ref, row, col, val as double))
-            : cvRun(() => CFFI.Mat_SetFloat3(ref, row, col, i2, val as double));
-      case MatType.CV_64F:
-        assert(T == double, "$type only support double");
-        type.channels == 1 || i2 == null
-            ? cvRun(() => CFFI.Mat_SetDouble(ref, row, col, val as double))
-            : cvRun(() => CFFI.Mat_SetDouble3(ref, row, col, i2, val as double));
-      default:
-        throw UnsupportedError("setValue() for $type is not supported!");
-    }
-  }
-
-  void _setVec<T>(int row, int col, T val) {
+  void setVec<T>(int row, int col, T val) {
     cvRunArena((arena) {
       // Vec2b, Vec3b, Vec4b
       if (val is Vec2b) {
@@ -544,8 +502,54 @@ class Mat extends CvStruct<cvg.Mat> {
     });
   }
 
+  void setU8(int row, int col, int val, [int? i2]) => i2 == null
+      ? cvRun(() => CFFI.Mat_SetUChar(ref, row, col, val))
+      : cvRun(() => CFFI.Mat_SetUChar3(ref, row, col, i2, val));
+
+  void setI8(int row, int col, int val, [int? i2]) => i2 == null
+      ? cvRun(() => CFFI.Mat_SetSChar(ref, row, col, val))
+      : cvRun(() => CFFI.Mat_SetSChar3(ref, row, col, i2, val));
+
+  void setU16(int row, int col, int val, [int? i2]) => i2 == null
+      ? cvRun(() => CFFI.Mat_SetUShort(ref, row, col, val))
+      : cvRun(() => CFFI.Mat_SetUShort3(ref, row, col, i2, val));
+
+  void setI16(int row, int col, int val, [int? i2]) => i2 == null
+      ? cvRun(() => CFFI.Mat_SetShort(ref, row, col, val))
+      : cvRun(() => CFFI.Mat_SetShort3(ref, row, col, i2, val));
+
+  void setI32(int row, int col, int val, [int? i2]) => i2 == null
+      ? cvRun(() => CFFI.Mat_SetInt(ref, row, col, val))
+      : cvRun(() => CFFI.Mat_SetInt3(ref, row, col, i2, val));
+
+  void setF32(int row, int col, double val, [int? i2]) => i2 == null
+      ? cvRun(() => CFFI.Mat_SetFloat(ref, row, col, val))
+      : cvRun(() => CFFI.Mat_SetFloat3(ref, row, col, i2, val));
+
+  void setF64(int row, int col, double val, [int? i2]) => i2 == null
+      ? cvRun(() => CFFI.Mat_SetDouble(ref, row, col, val))
+      : cvRun(() => CFFI.Mat_SetDouble3(ref, row, col, i2, val));
+
+  void setNum<T extends num>(int row, int col, T val, [int? i2]) {
+    using((arena) {
+      final p = arena<ffi.Int>();
+      cvRun(() => CFFI.Mat_Type(ref, p));
+      final depth = p.value & (MatType.CV_DEPTH_MAX - 1);
+      return switch (depth) {
+        MatType.CV_8U => setU8(row, col, val as int, i2),
+        MatType.CV_8S => setI8(row, col, val as int, i2),
+        MatType.CV_16U => setU16(row, col, val as int, i2),
+        MatType.CV_16S => setI16(row, col, val as int, i2),
+        MatType.CV_32S => setI32(row, col, val as int, i2),
+        MatType.CV_32F => setF32(row, col, val as double, i2),
+        MatType.CV_64F => setF64(row, col, val as double, i2),
+        _ => throw UnsupportedError("Unsupported type: $type")
+      };
+    });
+  }
+
   /// equivalent to Mat::at\<T\>(i0, i1, i2) = val;
-  /// where T might be int, double.
+  /// where T might be int, double, [U8], [I8], [U16], [I16], [I32], [F32], [F64].
   /// or cv::Vec<> like cv::Vec3b
   ///
   /// example
@@ -555,13 +559,27 @@ class Mat extends CvStruct<cvg.Mat> {
   /// m.set<cv.Vec3f>(0, 0, cv.Vec3f(9, 9, 9));
   /// m.at<cv.Vec3f>(0, 0); // cv.Vec3f(9, 9, 9)
   /// ```
-  void set<T>(int row, int col, T val, [int? i2]) {
+  void set<T>(int row, int col, Object val, [int? i2]) {
     if (T == int || T == double) {
-      _setNum<T>(row, col, val, i2);
+      setNum(row, col, val as num, i2);
     } else if (isSubtype<T, CvVec>()) {
-      _setVec<T>(row, col, val);
+      setVec<T>(row, col, val as T);
+    } else if (T == U8) {
+      setU8(row, col, val as int);
+    } else if (T == I8) {
+      setI8(row, col, val as int);
+    } else if (T == U16) {
+      setU16(row, col, val as int);
+    } else if (T == I16) {
+      setI16(row, col, val as int);
+    } else if (T == I32) {
+      setI32(row, col, val as int);
+    } else if (T == F32) {
+      setF32(row, col, val as double);
+    } else if (T == F64) {
+      setF64(row, col, val as double);
     } else {
-      throw UnsupportedError("T must be num or CvVec(e.g., Vec3b), but got $T");
+      throw UnsupportedError("Unsupported type $T");
     }
   }
 

--- a/lib/src/core/mat_type.dart
+++ b/lib/src/core/mat_type.dart
@@ -102,7 +102,7 @@ class MatType extends Equatable {
       CV_64FC4 = CV_64FC(4);
 
   /*
-    static const int 
+    static const int
         CV_8UC1 = 0,
         CV_8SC1 = 1,
         CV_16UC1 = 2,

--- a/test/calib3d_test.dart
+++ b/test/calib3d_test.dart
@@ -8,16 +8,16 @@ void main() async {
     expect(img.isEmpty, false);
     final k = cv.Mat.zeros(3, 3, cv.MatType.CV_64FC1);
     k.set<double>(0, 0, 689.21);
-    k.set<double>(0, 1, 0);
+    k.set<double>(0, 1, 0.0);
     k.set<double>(0, 2, 1295.56);
 
-    k.set<double>(1, 0, 0);
+    k.set<double>(1, 0, 0.0);
     k.set<double>(1, 1, 690.48);
     k.set<double>(1, 2, 942.17);
 
-    k.set<double>(2, 0, 0);
-    k.set<double>(2, 1, 0);
-    k.set<double>(2, 2, 1);
+    k.set<double>(2, 0, 0.0);
+    k.set<double>(2, 1, 0.0);
+    k.set<double>(2, 2, 1.0);
 
     final d = cv.Mat.zeros(1, 4, cv.MatType.CV_64FC1);
 
@@ -28,16 +28,16 @@ void main() async {
   test('cv.undistortPoints', () {
     final k = cv.Mat.zeros(3, 3, cv.MatType.CV_64FC1);
     k.set<double>(0, 0, 1094.7249578198823);
-    k.set<double>(0, 1, 0);
+    k.set<double>(0, 1, 0.0);
     k.set<double>(0, 2, 1094.7249578198823);
 
-    k.set<double>(1, 0, 0);
+    k.set<double>(1, 0, 0.0);
     k.set<double>(1, 1, 1094.9945708128778);
     k.set<double>(1, 2, 536.4566143451868);
 
-    k.set<double>(2, 0, 0);
-    k.set<double>(2, 1, 0);
-    k.set<double>(2, 2, 1);
+    k.set<double>(2, 0, 0.0);
+    k.set<double>(2, 1, 0.0);
+    k.set<double>(2, 2, 1.0);
 
     final d = cv.Mat.zeros(1, 4, cv.MatType.CV_64FC1);
     d.set<double>(0, 0, -0.05207412392075069);
@@ -57,14 +57,14 @@ void main() async {
     // (0 * 2) + channelNumber
     // so col = 0 is the x coordinate and col = 1 is the y coordinate
 
-    src.set<double>(0, 0, 480);
-    src.set<double>(0, 1, 270);
+    src.set<double>(0, 0, 480.0);
+    src.set<double>(0, 1, 270.0);
 
-    src.set<double>(1, 0, 960);
-    src.set<double>(1, 1, 540);
+    src.set<double>(1, 0, 960.0);
+    src.set<double>(1, 1, 540.0);
 
-    src.set<double>(2, 0, 1920);
-    src.set<double>(2, 1, 1080);
+    src.set<double>(2, 0, 1920.0);
+    src.set<double>(2, 1, 1080.0);
 
     cv.undistortPoints(src, k, d);
     final dst = cv.undistortPoints(src, k, d, R: r, P: k);
@@ -76,16 +76,16 @@ void main() async {
   test('cv.Fisheye.undistortPoints', () {
     final k = cv.Mat.zeros(3, 3, cv.MatType.CV_64FC1);
     k.set<double>(0, 0, 1094.7249578198823);
-    k.set<double>(0, 1, 0);
+    k.set<double>(0, 1, 0.0);
     k.set<double>(0, 2, 959.4907612030962);
 
-    k.set<double>(1, 0, 0);
+    k.set<double>(1, 0, 0.0);
     k.set<double>(1, 1, 1094.9945708128778);
     k.set<double>(1, 2, 536.4566143451868);
 
-    k.set<double>(2, 0, 0);
-    k.set<double>(2, 1, 0);
-    k.set<double>(2, 2, 1);
+    k.set<double>(2, 0, 0.0);
+    k.set<double>(2, 1, 0.0);
+    k.set<double>(2, 2, 1.0);
 
     final d = cv.Mat.zeros(1, 4, cv.MatType.CV_64FC1);
     d.set<double>(0, 0, -0.05207412392075069);
@@ -97,14 +97,14 @@ void main() async {
     final src = cv.Mat.zeros(3, 1, cv.MatType.CV_64FC2);
     final dst = cv.Mat.zeros(3, 1, cv.MatType.CV_64FC2);
 
-    src.set<double>(0, 0, 480);
-    src.set<double>(0, 1, 270);
+    src.set<double>(0, 0, 480.0);
+    src.set<double>(0, 1, 270.0);
 
-    src.set<double>(1, 0, 960);
-    src.set<double>(1, 1, 540);
+    src.set<double>(1, 0, 960.0);
+    src.set<double>(1, 1, 540.0);
 
-    src.set<double>(2, 0, 1440);
-    src.set<double>(2, 1, 810);
+    src.set<double>(2, 0, 1440.0);
+    src.set<double>(2, 1, 810.0);
 
     final knew = k.clone();
     knew.set<double>(0, 0, 0.4 * k.at<double>(0, 0));
@@ -133,16 +133,16 @@ void main() async {
 
     final k = cv.Mat.zeros(3, 3, cv.MatType.CV_64FC1);
     k.set<double>(0, 0, 842.0261028);
-    k.set<double>(0, 1, 0);
+    k.set<double>(0, 1, 0.0);
     k.set<double>(0, 2, 667.7569792);
 
-    k.set<double>(1, 0, 0);
+    k.set<double>(1, 0, 0.0);
     k.set<double>(1, 1, 707.3668897);
     k.set<double>(1, 2, 385.56476464);
 
-    k.set<double>(2, 0, 0);
-    k.set<double>(2, 1, 0);
-    k.set<double>(2, 2, 1);
+    k.set<double>(2, 0, 0.0);
+    k.set<double>(2, 1, 0.0);
+    k.set<double>(2, 2, 1.0);
 
     final d = cv.Mat.zeros(1, 5, cv.MatType.CV_64FC1);
     d.set<double>(0, 0, -3.65584802e-01);

--- a/test/contrib/img_hash_test.dart
+++ b/test/contrib/img_hash_test.dart
@@ -44,7 +44,7 @@ void main() async {
     final img = cv.Mat.ones(256, 256, cv.MatType.CV_8UC1);
     for (var i = 0; i < img.rows; i++) {
       for (var j = 0; j < img.cols; j++) {
-        img.set(i, j, i + j);
+        img.set<cv.U8>(i, j, i + j);
       }
     }
     bmh.compute(img, hash);

--- a/test/video_test.dart
+++ b/test/video_test.dart
@@ -64,8 +64,8 @@ void main() async {
     expect(img.isEmpty, false);
     final testImg = cv.resize(img, (216, 216));
     final translationGround = cv.Mat.eye(2, 3, cv.MatType.CV_32FC1);
-    translationGround.set(0, 2, 11.4159);
-    translationGround.set(1, 2, 17.1828);
+    translationGround.set<double>(0, 2, 11.4159);
+    translationGround.setF64(1, 2, 17.1828);
 
     final wrappedImage = cv.warpAffine(
       testImg,


### PR DESCRIPTION
Releated:
- #53 
- #44 

simple perf test:
```bash
Mat(3840, 2160, CV_8UC1).at: 6937ms
Mat(3840, 2160, CV_8UC1).atU8: 4701ms
Mat(3840, 2160, CV_8UC1).set: 6188ms
Mat(3840, 2160, CV_8UC1).setU8: 3124ms
```

Maybe faster with Native Assets:
```bash
00:10 +305 ~2: test\core\mat_test.dart: Mat at set perf
Mat(3840, 2160, CV_8UC1).at: 6394ms
Mat(3840, 2160, CV_8UC1).atU8: 4512ms
Mat(3840, 2160, CV_8UC1).set: 5258ms
Mat(3840, 2160, CV_8UC1).setU8: 2829ms
```

at: Mat.atU8, Mat.atI8, Mat.atU16, Mat.atI16, Mat.atI32, Mat.atF32, Mat.atF64

set: Mat.setU8, Mat.setI8, Mat.setU16, Mat.setI16, Mat.setI32, Mat.setF32, Mat.setF64

Mat.set support native types, e.g., Mat.set<cv.U8>()

In previous version, determine the Mat type is very expensive, but considering the mat type may change after creation, so it has to be get from native pointer, which costs lots of time, so for performance sensitive occasions, use atU8/setU8-like API.