### PR TITLE
hotfix: update binary version of v1.0.5+1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opencv_dart
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 1.0.5+1
-binary_version: 1.0.5
+version: 1.0.5+2
+binary_version: 1.0.5+2
 homepage: https://github.com/rainyl/opencv_dart
 
 environment:


### PR DESCRIPTION
the binary version of v1.0.5+1 is wrong, which should be build with new libs