### PR TITLE
remove CVD_TYPEDEF_PTR to clean codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ conan toolchain for linux arm is located in [opencv.full](https://github.com/rai
 
 ## Contributors
 
-<!-- readme: contributors -start -->
+<!-- readme: contributors,<TotemaT>/- -start -->
 <table>
 	<tbody>
 		<tr>
@@ -304,7 +304,7 @@ conan toolchain for linux arm is located in [opencv.full](https://github.com/rai
 		</tr>
 	<tbody>
 </table>
-<!-- readme: contributors -end -->
+<!-- readme: contributors,<TotemaT>/- -end -->
 
 ## Acknowledgement
 

--- a/lib/src/opencv.g.dart
+++ b/lib/src/opencv.g.dart
@@ -29,7 +29,7 @@ class CvNative {
       : _lookup = lookup;
 
   void AKAZE_Close(
-    ffi.Pointer<AKAZE> a,
+    AKAZEPtr a,
   ) {
     return _AKAZE_Close(
       a,
@@ -37,10 +37,9 @@ class CvNative {
   }
 
   late final _AKAZE_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<AKAZE>)>>(
-          'AKAZE_Close');
+      _lookup<ffi.NativeFunction<ffi.Void Function(AKAZEPtr)>>('AKAZE_Close');
   late final _AKAZE_Close =
-      _AKAZE_ClosePtr.asFunction<void Function(ffi.Pointer<AKAZE>)>();
+      _AKAZE_ClosePtr.asFunction<void Function(AKAZEPtr)>();
 
   CvStatus AKAZE_Create(
     ffi.Pointer<AKAZE> rval,
@@ -126,19 +125,18 @@ class CvNative {
       CvStatus Function(Mat, Mat, double, int, int, int, double)>();
 
   void AgastFeatureDetector_Close(
-    ffi.Pointer<AgastFeatureDetector> a,
+    AgastFeatureDetectorPtr a,
   ) {
     return _AgastFeatureDetector_Close(
       a,
     );
   }
 
-  late final _AgastFeatureDetector_ClosePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<AgastFeatureDetector>)>>(
-      'AgastFeatureDetector_Close');
+  late final _AgastFeatureDetector_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(AgastFeatureDetectorPtr)>>(
+          'AgastFeatureDetector_Close');
   late final _AgastFeatureDetector_Close = _AgastFeatureDetector_ClosePtr
-      .asFunction<void Function(ffi.Pointer<AgastFeatureDetector>)>();
+      .asFunction<void Function(AgastFeatureDetectorPtr)>();
 
   CvStatus AgastFeatureDetector_Create(
     ffi.Pointer<AgastFeatureDetector> rval,
@@ -177,7 +175,7 @@ class CvNative {
               AgastFeatureDetector, Mat, ffi.Pointer<VecKeyPoint>)>();
 
   void AlignMTB_Close(
-    ffi.Pointer<AlignMTB> b,
+    AlignMTBPtr b,
   ) {
     return _AlignMTB_Close(
       b,
@@ -185,10 +183,10 @@ class CvNative {
   }
 
   late final _AlignMTB_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<AlignMTB>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(AlignMTBPtr)>>(
           'AlignMTB_Close');
   late final _AlignMTB_Close =
-      _AlignMTB_ClosePtr.asFunction<void Function(ffi.Pointer<AlignMTB>)>();
+      _AlignMTB_ClosePtr.asFunction<void Function(AlignMTBPtr)>();
 
   CvStatus AlignMTB_Create(
     ffi.Pointer<AlignMTB> rval,
@@ -350,7 +348,7 @@ class CvNative {
       CvStatus Function(Mat, Point, Point, Scalar, int, int, int, double)>();
 
   void ArucoDetectorParameters_Close(
-    ffi.Pointer<ArucoDetectorParameters> ap,
+    ArucoDetectorParametersPtr ap,
   ) {
     return _ArucoDetectorParameters_Close(
       ap,
@@ -358,11 +356,10 @@ class CvNative {
   }
 
   late final _ArucoDetectorParameters_ClosePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<ArucoDetectorParameters>)>>(
+          ffi.NativeFunction<ffi.Void Function(ArucoDetectorParametersPtr)>>(
       'ArucoDetectorParameters_Close');
   late final _ArucoDetectorParameters_Close = _ArucoDetectorParameters_ClosePtr
-      .asFunction<void Function(ffi.Pointer<ArucoDetectorParameters>)>();
+      .asFunction<void Function(ArucoDetectorParametersPtr)>();
 
   CvStatus ArucoDetectorParameters_Create(
     ffi.Pointer<ArucoDetectorParameters> rval,
@@ -1478,18 +1475,18 @@ class CvNative {
           CvStatus Function(ArucoDetectorParameters, double)>();
 
   void ArucoDetector_Close(
-    ffi.Pointer<ArucoDetector> ad,
+    ArucoDetectorPtr ad,
   ) {
     return _ArucoDetector_Close(
       ad,
     );
   }
 
-  late final _ArucoDetector_ClosePtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ArucoDetector>)>>(
-      'ArucoDetector_Close');
-  late final _ArucoDetector_Close = _ArucoDetector_ClosePtr.asFunction<
-      void Function(ffi.Pointer<ArucoDetector>)>();
+  late final _ArucoDetector_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ArucoDetectorPtr)>>(
+          'ArucoDetector_Close');
+  late final _ArucoDetector_Close =
+      _ArucoDetector_ClosePtr.asFunction<void Function(ArucoDetectorPtr)>();
 
   CvStatus ArucoDetector_DetectMarkers(
     ArucoDetector ad,
@@ -1556,18 +1553,18 @@ class CvNative {
               ffi.Pointer<ArucoDetector>)>();
 
   void ArucoDictionary_Close(
-    ffi.Pointer<ArucoDictionary> self,
+    ArucoDictionaryPtr self,
   ) {
     return _ArucoDictionary_Close(
       self,
     );
   }
 
-  late final _ArucoDictionary_ClosePtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ArucoDictionary>)>>(
-      'ArucoDictionary_Close');
-  late final _ArucoDictionary_Close = _ArucoDictionary_ClosePtr.asFunction<
-      void Function(ffi.Pointer<ArucoDictionary>)>();
+  late final _ArucoDictionary_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ArucoDictionaryPtr)>>(
+          'ArucoDictionary_Close');
+  late final _ArucoDictionary_Close =
+      _ArucoDictionary_ClosePtr.asFunction<void Function(ArucoDictionaryPtr)>();
 
   CvStatus ArucoDrawDetectedMarkers(
     Mat image,
@@ -1614,7 +1611,7 @@ class CvNative {
       .asFunction<CvStatus Function(int, int, int, Mat, int)>();
 
   void AsyncArray_Close(
-    ffi.Pointer<AsyncArray> a,
+    AsyncArrayPtr a,
   ) {
     return _AsyncArray_Close(
       a,
@@ -1622,10 +1619,10 @@ class CvNative {
   }
 
   late final _AsyncArray_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<AsyncArray>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(AsyncArrayPtr)>>(
           'AsyncArray_Close');
   late final _AsyncArray_Close =
-      _AsyncArray_ClosePtr.asFunction<void Function(ffi.Pointer<AsyncArray>)>();
+      _AsyncArray_ClosePtr.asFunction<void Function(AsyncArrayPtr)>();
 
   CvStatus AsyncArray_Get(
     AsyncArray async_out,
@@ -1658,7 +1655,7 @@ class CvNative {
       CvStatus Function(ffi.Pointer<AsyncArray>)>();
 
   void BFMatcher_Close(
-    ffi.Pointer<BFMatcher> b,
+    BFMatcherPtr b,
   ) {
     return _BFMatcher_Close(
       b,
@@ -1666,10 +1663,10 @@ class CvNative {
   }
 
   late final _BFMatcher_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<BFMatcher>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(BFMatcherPtr)>>(
           'BFMatcher_Close');
   late final _BFMatcher_Close =
-      _BFMatcher_ClosePtr.asFunction<void Function(ffi.Pointer<BFMatcher>)>();
+      _BFMatcher_ClosePtr.asFunction<void Function(BFMatcherPtr)>();
 
   CvStatus BFMatcher_Create(
     ffi.Pointer<BFMatcher> rval,
@@ -1749,7 +1746,7 @@ class CvNative {
       CvStatus Function(BFMatcher, Mat, Mat, ffi.Pointer<VecDMatch>)>();
 
   void BRISK_Close(
-    ffi.Pointer<BRISK> b,
+    BRISKPtr b,
   ) {
     return _BRISK_Close(
       b,
@@ -1757,10 +1754,9 @@ class CvNative {
   }
 
   late final _BRISK_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<BRISK>)>>(
-          'BRISK_Close');
+      _lookup<ffi.NativeFunction<ffi.Void Function(BRISKPtr)>>('BRISK_Close');
   late final _BRISK_Close =
-      _BRISK_ClosePtr.asFunction<void Function(ffi.Pointer<BRISK>)>();
+      _BRISK_ClosePtr.asFunction<void Function(BRISKPtr)>();
 
   CvStatus BRISK_Create(
     ffi.Pointer<BRISK> rval,
@@ -1838,7 +1834,7 @@ class CvNative {
       .asFunction<CvStatus Function(BackgroundSubtractorKNN, Mat, Mat)>();
 
   void BackgroundSubtractorKNN_Close(
-    ffi.Pointer<BackgroundSubtractorKNN> self,
+    BackgroundSubtractorKNNPtr self,
   ) {
     return _BackgroundSubtractorKNN_Close(
       self,
@@ -1846,11 +1842,10 @@ class CvNative {
   }
 
   late final _BackgroundSubtractorKNN_ClosePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<BackgroundSubtractorKNN>)>>(
+          ffi.NativeFunction<ffi.Void Function(BackgroundSubtractorKNNPtr)>>(
       'BackgroundSubtractorKNN_Close');
   late final _BackgroundSubtractorKNN_Close = _BackgroundSubtractorKNN_ClosePtr
-      .asFunction<void Function(ffi.Pointer<BackgroundSubtractorKNN>)>();
+      .asFunction<void Function(BackgroundSubtractorKNNPtr)>();
 
   CvStatus BackgroundSubtractorKNN_Create(
     ffi.Pointer<BackgroundSubtractorKNN> rval,
@@ -1913,7 +1908,7 @@ class CvNative {
           CvStatus Function(BackgroundSubtractorMOG2, Mat, Mat)>();
 
   void BackgroundSubtractorMOG2_Close(
-    ffi.Pointer<BackgroundSubtractorMOG2> self,
+    BackgroundSubtractorMOG2Ptr self,
   ) {
     return _BackgroundSubtractorMOG2_Close(
       self,
@@ -1921,12 +1916,11 @@ class CvNative {
   }
 
   late final _BackgroundSubtractorMOG2_ClosePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<BackgroundSubtractorMOG2>)>>(
+          ffi.NativeFunction<ffi.Void Function(BackgroundSubtractorMOG2Ptr)>>(
       'BackgroundSubtractorMOG2_Close');
   late final _BackgroundSubtractorMOG2_Close =
       _BackgroundSubtractorMOG2_ClosePtr.asFunction<
-          void Function(ffi.Pointer<BackgroundSubtractorMOG2>)>();
+          void Function(BackgroundSubtractorMOG2Ptr)>();
 
   CvStatus BackgroundSubtractorMOG2_Create(
     ffi.Pointer<BackgroundSubtractorMOG2> rval,
@@ -1992,18 +1986,18 @@ class CvNative {
       CvStatus Function(Mat, Mat, int, double, double)>();
 
   void BlockMeanHash_Close(
-    ffi.Pointer<BlockMeanHash> self,
+    BlockMeanHashPtr self,
   ) {
     return _BlockMeanHash_Close(
       self,
     );
   }
 
-  late final _BlockMeanHash_ClosePtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<BlockMeanHash>)>>(
-      'BlockMeanHash_Close');
-  late final _BlockMeanHash_Close = _BlockMeanHash_ClosePtr.asFunction<
-      void Function(ffi.Pointer<BlockMeanHash>)>();
+  late final _BlockMeanHash_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(BlockMeanHashPtr)>>(
+          'BlockMeanHash_Close');
+  late final _BlockMeanHash_Close =
+      _BlockMeanHash_ClosePtr.asFunction<void Function(BlockMeanHashPtr)>();
 
   CvStatus BlockMeanHash_Compare(
     BlockMeanHash self,
@@ -2185,7 +2179,7 @@ class CvNative {
       _CLAHE_ApplyPtr.asFunction<CvStatus Function(CLAHE, Mat, Mat)>();
 
   void CLAHE_Close(
-    ffi.Pointer<CLAHE> c,
+    CLAHEPtr c,
   ) {
     return _CLAHE_Close(
       c,
@@ -2193,10 +2187,9 @@ class CvNative {
   }
 
   late final _CLAHE_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<CLAHE>)>>(
-          'CLAHE_Close');
+      _lookup<ffi.NativeFunction<ffi.Void Function(CLAHEPtr)>>('CLAHE_Close');
   late final _CLAHE_Close =
-      _CLAHE_ClosePtr.asFunction<void Function(ffi.Pointer<CLAHE>)>();
+      _CLAHE_ClosePtr.asFunction<void Function(CLAHEPtr)>();
 
   CvStatus CLAHE_CollectGarbage(
     CLAHE c,
@@ -2558,19 +2551,18 @@ class CvNative {
       CvStatus Function(Mat, Mat, double, double, int, bool)>();
 
   void CascadeClassifier_Close(
-    ffi.Pointer<CascadeClassifier> self,
+    CascadeClassifierPtr self,
   ) {
     return _CascadeClassifier_Close(
       self,
     );
   }
 
-  late final _CascadeClassifier_ClosePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<CascadeClassifier>)>>(
-      'CascadeClassifier_Close');
+  late final _CascadeClassifier_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(CascadeClassifierPtr)>>(
+          'CascadeClassifier_Close');
   late final _CascadeClassifier_Close = _CascadeClassifier_ClosePtr.asFunction<
-      void Function(ffi.Pointer<CascadeClassifier>)>();
+      void Function(CascadeClassifierPtr)>();
 
   CvStatus CascadeClassifier_DetectMultiScale(
     CascadeClassifier self,
@@ -3638,19 +3630,18 @@ class CvNative {
       _EyePtr.asFunction<CvStatus Function(int, int, int, ffi.Pointer<Mat>)>();
 
   void FastFeatureDetector_Close(
-    ffi.Pointer<FastFeatureDetector> f,
+    FastFeatureDetectorPtr f,
   ) {
     return _FastFeatureDetector_Close(
       f,
     );
   }
 
-  late final _FastFeatureDetector_ClosePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<FastFeatureDetector>)>>(
-      'FastFeatureDetector_Close');
+  late final _FastFeatureDetector_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(FastFeatureDetectorPtr)>>(
+          'FastFeatureDetector_Close');
   late final _FastFeatureDetector_Close = _FastFeatureDetector_ClosePtr
-      .asFunction<void Function(ffi.Pointer<FastFeatureDetector>)>();
+      .asFunction<void Function(FastFeatureDetectorPtr)>();
 
   CvStatus FastFeatureDetector_Create(
     ffi.Pointer<FastFeatureDetector> rval,
@@ -4212,19 +4203,18 @@ class CvNative {
       CvStatus Function(VecPoint, Mat, int, double, double, double)>();
 
   void FlannBasedMatcher_Close(
-    ffi.Pointer<FlannBasedMatcher> f,
+    FlannBasedMatcherPtr f,
   ) {
     return _FlannBasedMatcher_Close(
       f,
     );
   }
 
-  late final _FlannBasedMatcher_ClosePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<FlannBasedMatcher>)>>(
-      'FlannBasedMatcher_Close');
+  late final _FlannBasedMatcher_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(FlannBasedMatcherPtr)>>(
+          'FlannBasedMatcher_Close');
   late final _FlannBasedMatcher_Close = _FlannBasedMatcher_ClosePtr.asFunction<
-      void Function(ffi.Pointer<FlannBasedMatcher>)>();
+      void Function(FlannBasedMatcherPtr)>();
 
   CvStatus FlannBasedMatcher_Create(
     ffi.Pointer<FlannBasedMatcher> rval,
@@ -4267,7 +4257,7 @@ class CvNative {
               FlannBasedMatcher, Mat, Mat, int, ffi.Pointer<VecVecDMatch>)>();
 
   void GFTTDetector_Close(
-    ffi.Pointer<GFTTDetector> a,
+    GFTTDetectorPtr a,
   ) {
     return _GFTTDetector_Close(
       a,
@@ -4275,10 +4265,10 @@ class CvNative {
   }
 
   late final _GFTTDetector_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<GFTTDetector>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(GFTTDetectorPtr)>>(
           'GFTTDetector_Close');
-  late final _GFTTDetector_Close = _GFTTDetector_ClosePtr.asFunction<
-      void Function(ffi.Pointer<GFTTDetector>)>();
+  late final _GFTTDetector_Close =
+      _GFTTDetector_ClosePtr.asFunction<void Function(GFTTDetectorPtr)>();
 
   CvStatus GFTTDetector_Create(
     ffi.Pointer<GFTTDetector> rval,
@@ -4741,18 +4731,18 @@ class CvNative {
       _GroupRectanglesPtr.asFunction<CvStatus Function(VecRect, int, double)>();
 
   void HOGDescriptor_Close(
-    ffi.Pointer<HOGDescriptor> self,
+    HOGDescriptorPtr self,
   ) {
     return _HOGDescriptor_Close(
       self,
     );
   }
 
-  late final _HOGDescriptor_ClosePtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<HOGDescriptor>)>>(
-      'HOGDescriptor_Close');
-  late final _HOGDescriptor_Close = _HOGDescriptor_ClosePtr.asFunction<
-      void Function(ffi.Pointer<HOGDescriptor>)>();
+  late final _HOGDescriptor_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(HOGDescriptorPtr)>>(
+          'HOGDescriptor_Close');
+  late final _HOGDescriptor_Close =
+      _HOGDescriptor_ClosePtr.asFunction<void Function(HOGDescriptorPtr)>();
 
   CvStatus HOGDescriptor_Compute(
     HOGDescriptor self,
@@ -5500,7 +5490,7 @@ class CvNative {
       _InvertAffineTransformPtr.asFunction<CvStatus Function(Mat, Mat)>();
 
   void KAZE_Close(
-    ffi.Pointer<KAZE> a,
+    KAZEPtr a,
   ) {
     return _KAZE_Close(
       a,
@@ -5508,10 +5498,8 @@ class CvNative {
   }
 
   late final _KAZE_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<KAZE>)>>(
-          'KAZE_Close');
-  late final _KAZE_Close =
-      _KAZE_ClosePtr.asFunction<void Function(ffi.Pointer<KAZE>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(KAZEPtr)>>('KAZE_Close');
+  late final _KAZE_Close = _KAZE_ClosePtr.asFunction<void Function(KAZEPtr)>();
 
   CvStatus KAZE_Create(
     ffi.Pointer<KAZE> rval,
@@ -5630,7 +5618,7 @@ class CvNative {
           ffi.Pointer<ffi.Double>)>();
 
   void KalmanFilter_Close(
-    ffi.Pointer<KalmanFilter> self,
+    KalmanFilterPtr self,
   ) {
     return _KalmanFilter_Close(
       self,
@@ -5638,10 +5626,10 @@ class CvNative {
   }
 
   late final _KalmanFilter_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<KalmanFilter>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(KalmanFilterPtr)>>(
           'KalmanFilter_Close');
-  late final _KalmanFilter_Close = _KalmanFilter_ClosePtr.asFunction<
-      void Function(ffi.Pointer<KalmanFilter>)>();
+  late final _KalmanFilter_Close =
+      _KalmanFilter_ClosePtr.asFunction<void Function(KalmanFilterPtr)>();
 
   CvStatus KalmanFilter_Correct(
     KalmanFilter self,
@@ -6231,7 +6219,7 @@ class CvNative {
       CvStatus Function(Mat, Mat, int, int, double, double, int)>();
 
   void Layer_Close(
-    ffi.Pointer<Layer> layer,
+    LayerPtr layer,
   ) {
     return _Layer_Close(
       layer,
@@ -6239,10 +6227,9 @@ class CvNative {
   }
 
   late final _Layer_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Layer>)>>(
-          'Layer_Close');
+      _lookup<ffi.NativeFunction<ffi.Void Function(LayerPtr)>>('Layer_Close');
   late final _Layer_Close =
-      _Layer_ClosePtr.asFunction<void Function(ffi.Pointer<Layer>)>();
+      _Layer_ClosePtr.asFunction<void Function(LayerPtr)>();
 
   CvStatus Layer_GetName(
     Layer layer,
@@ -6390,7 +6377,7 @@ class CvNative {
       CvStatus Function(Mat, Mat, Point2f, double, int)>();
 
   void MSER_Close(
-    ffi.Pointer<MSER> a,
+    MSERPtr a,
   ) {
     return _MSER_Close(
       a,
@@ -6398,10 +6385,8 @@ class CvNative {
   }
 
   late final _MSER_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MSER>)>>(
-          'MSER_Close');
-  late final _MSER_Close =
-      _MSER_ClosePtr.asFunction<void Function(ffi.Pointer<MSER>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(MSERPtr)>>('MSER_Close');
+  late final _MSER_Close = _MSER_ClosePtr.asFunction<void Function(MSERPtr)>();
 
   CvStatus MSER_Create(
     ffi.Pointer<MSER> rval,
@@ -7027,7 +7012,7 @@ class CvNative {
       _Mat_ClonePtr.asFunction<CvStatus Function(Mat, ffi.Pointer<Mat>)>();
 
   void Mat_Close(
-    ffi.Pointer<Mat> m,
+    MatPtr m,
   ) {
     return _Mat_Close(
       m,
@@ -7035,10 +7020,8 @@ class CvNative {
   }
 
   late final _Mat_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Mat>)>>(
-          'Mat_Close');
-  late final _Mat_Close =
-      _Mat_ClosePtr.asFunction<void Function(ffi.Pointer<Mat>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(MatPtr)>>('Mat_Close');
+  late final _Mat_Close = _Mat_ClosePtr.asFunction<void Function(MatPtr)>();
 
   void Mat_CloseVoid(
     ffi.Pointer<ffi.Void> m,
@@ -11265,7 +11248,7 @@ class CvNative {
       _MedianBlurPtr.asFunction<CvStatus Function(Mat, Mat, int)>();
 
   void MergeMertens_Close(
-    ffi.Pointer<MergeMertens> b,
+    MergeMertensPtr b,
   ) {
     return _MergeMertens_Close(
       b,
@@ -11273,10 +11256,10 @@ class CvNative {
   }
 
   late final _MergeMertens_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MergeMertens>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(MergeMertensPtr)>>(
           'MergeMertens_Close');
-  late final _MergeMertens_Close = _MergeMertens_ClosePtr.asFunction<
-      void Function(ffi.Pointer<MergeMertens>)>();
+  late final _MergeMertens_Close =
+      _MergeMertens_ClosePtr.asFunction<void Function(MergeMertensPtr)>();
 
   CvStatus MergeMertens_Create(
     ffi.Pointer<MergeMertens> rval,
@@ -11562,7 +11545,7 @@ class CvNative {
       CvStatus Function(VecMat, Mat, double, Size, Scalar, bool, bool, int)>();
 
   void Net_Close(
-    ffi.Pointer<Net> net,
+    NetPtr net,
   ) {
     return _Net_Close(
       net,
@@ -11570,10 +11553,8 @@ class CvNative {
   }
 
   late final _Net_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Net>)>>(
-          'Net_Close');
-  late final _Net_Close =
-      _Net_ClosePtr.asFunction<void Function(ffi.Pointer<Net>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(NetPtr)>>('Net_Close');
+  late final _Net_Close = _Net_ClosePtr.asFunction<void Function(NetPtr)>();
 
   CvStatus Net_Create(
     ffi.Pointer<Net> rval,
@@ -12134,7 +12115,7 @@ class CvNative {
       CvStatus Function(Mat, Mat, int, ffi.Pointer<ffi.Double>)>();
 
   void ORB_Close(
-    ffi.Pointer<ORB> o,
+    ORBPtr o,
   ) {
     return _ORB_Close(
       o,
@@ -12142,10 +12123,8 @@ class CvNative {
   }
 
   late final _ORB_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ORB>)>>(
-          'ORB_Close');
-  late final _ORB_Close =
-      _ORB_ClosePtr.asFunction<void Function(ffi.Pointer<ORB>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ORBPtr)>>('ORB_Close');
+  late final _ORB_Close = _ORB_ClosePtr.asFunction<void Function(ORBPtr)>();
 
   CvStatus ORB_Create(
     ffi.Pointer<ORB> rval,
@@ -12491,18 +12470,18 @@ class CvNative {
       _PyrUpPtr.asFunction<CvStatus Function(Mat, Mat, Size, int)>();
 
   void QRCodeDetector_Close(
-    ffi.Pointer<QRCodeDetector> self,
+    QRCodeDetectorPtr self,
   ) {
     return _QRCodeDetector_Close(
       self,
     );
   }
 
-  late final _QRCodeDetector_ClosePtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<QRCodeDetector>)>>(
-      'QRCodeDetector_Close');
-  late final _QRCodeDetector_Close = _QRCodeDetector_ClosePtr.asFunction<
-      void Function(ffi.Pointer<QRCodeDetector>)>();
+  late final _QRCodeDetector_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(QRCodeDetectorPtr)>>(
+          'QRCodeDetector_Close');
+  late final _QRCodeDetector_Close =
+      _QRCodeDetector_ClosePtr.asFunction<void Function(QRCodeDetectorPtr)>();
 
   CvStatus QRCodeDetector_Decode(
     QRCodeDetector self,
@@ -13018,7 +12997,7 @@ class CvNative {
       CvStatus Function(Mat, Mat, Size, double, double, int)>();
 
   void Rng_Close(
-    ffi.Pointer<RNG> rng,
+    RNGPtr rng,
   ) {
     return _Rng_Close(
       rng,
@@ -13026,10 +13005,8 @@ class CvNative {
   }
 
   late final _Rng_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<RNG>)>>(
-          'Rng_Close');
-  late final _Rng_Close =
-      _Rng_ClosePtr.asFunction<void Function(ffi.Pointer<RNG>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(RNGPtr)>>('Rng_Close');
+  late final _Rng_Close = _Rng_ClosePtr.asFunction<void Function(RNGPtr)>();
 
   CvStatus Rng_New(
     ffi.Pointer<RNG> rval,
@@ -13131,7 +13108,7 @@ class CvNative {
       CvStatus Function(RotatedRect, ffi.Pointer<VecPoint2f>)>();
 
   void SIFT_Close(
-    ffi.Pointer<SIFT> f,
+    SIFTPtr f,
   ) {
     return _SIFT_Close(
       f,
@@ -13139,10 +13116,8 @@ class CvNative {
   }
 
   late final _SIFT_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<SIFT>)>>(
-          'SIFT_Close');
-  late final _SIFT_Close =
-      _SIFT_ClosePtr.asFunction<void Function(ffi.Pointer<SIFT>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(SIFTPtr)>>('SIFT_Close');
+  late final _SIFT_Close = _SIFT_ClosePtr.asFunction<void Function(SIFTPtr)>();
 
   CvStatus SIFT_Create(
     ffi.Pointer<SIFT> rval,
@@ -13347,19 +13322,18 @@ class CvNative {
           CvStatus Function(ffi.Pointer<SimpleBlobDetectorParams>)>();
 
   void SimpleBlobDetector_Close(
-    ffi.Pointer<SimpleBlobDetector> b,
+    SimpleBlobDetectorPtr b,
   ) {
     return _SimpleBlobDetector_Close(
       b,
     );
   }
 
-  late final _SimpleBlobDetector_ClosePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<SimpleBlobDetector>)>>(
-      'SimpleBlobDetector_Close');
+  late final _SimpleBlobDetector_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(SimpleBlobDetectorPtr)>>(
+          'SimpleBlobDetector_Close');
   late final _SimpleBlobDetector_Close = _SimpleBlobDetector_ClosePtr
-      .asFunction<void Function(ffi.Pointer<SimpleBlobDetector>)>();
+      .asFunction<void Function(SimpleBlobDetectorPtr)>();
 
   CvStatus SimpleBlobDetector_Create(
     ffi.Pointer<SimpleBlobDetector> rval,
@@ -13492,7 +13466,7 @@ class CvNative {
       _SqBoxFilterPtr.asFunction<CvStatus Function(Mat, Mat, int, Size)>();
 
   void Stitcher_Close(
-    ffi.Pointer<PtrStitcher> stitcher,
+    PtrStitcherPtr stitcher,
   ) {
     return _Stitcher_Close(
       stitcher,
@@ -13500,10 +13474,10 @@ class CvNative {
   }
 
   late final _Stitcher_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<PtrStitcher>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(PtrStitcherPtr)>>(
           'Stitcher_Close');
   late final _Stitcher_Close =
-      _Stitcher_ClosePtr.asFunction<void Function(ffi.Pointer<PtrStitcher>)>();
+      _Stitcher_ClosePtr.asFunction<void Function(PtrStitcherPtr)>();
 
   CvStatus Stitcher_Component(
     Stitcher self,
@@ -13920,7 +13894,7 @@ class CvNative {
       _StylizationPtr.asFunction<CvStatus Function(Mat, Mat, double, double)>();
 
   void Subdiv2D_Close(
-    ffi.Pointer<Subdiv2D> self,
+    Subdiv2DPtr self,
   ) {
     return _Subdiv2D_Close(
       self,
@@ -13928,10 +13902,10 @@ class CvNative {
   }
 
   late final _Subdiv2D_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Subdiv2D>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(Subdiv2DPtr)>>(
           'Subdiv2D_Close');
   late final _Subdiv2D_Close =
-      _Subdiv2D_ClosePtr.asFunction<void Function(ffi.Pointer<Subdiv2D>)>();
+      _Subdiv2D_ClosePtr.asFunction<void Function(Subdiv2DPtr)>();
 
   CvStatus Subdiv2D_EdgeDst(
     Subdiv2D self,
@@ -14471,7 +14445,7 @@ class CvNative {
       CvStatus Function(ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Char>, int)>();
 
   void TrackerMIL_Close(
-    ffi.Pointer<TrackerMIL> self,
+    TrackerMILPtr self,
   ) {
     return _TrackerMIL_Close(
       self,
@@ -14479,10 +14453,10 @@ class CvNative {
   }
 
   late final _TrackerMIL_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TrackerMIL>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(TrackerMILPtr)>>(
           'TrackerMIL_Close');
   late final _TrackerMIL_Close =
-      _TrackerMIL_ClosePtr.asFunction<void Function(ffi.Pointer<TrackerMIL>)>();
+      _TrackerMIL_ClosePtr.asFunction<void Function(TrackerMILPtr)>();
 
   CvStatus TrackerMIL_Create(
     ffi.Pointer<TrackerMIL> rval,
@@ -14623,7 +14597,7 @@ class CvNative {
       CvStatus Function(VecChar, int, ffi.Pointer<ffi.Char>)>();
 
   void VecChar_Close(
-    ffi.Pointer<VecChar> vec,
+    VecCharPtr vec,
   ) {
     return _VecChar_Close(
       vec,
@@ -14631,10 +14605,10 @@ class CvNative {
   }
 
   late final _VecChar_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecChar>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecCharPtr)>>(
           'VecChar_Close');
   late final _VecChar_Close =
-      _VecChar_ClosePtr.asFunction<void Function(ffi.Pointer<VecChar>)>();
+      _VecChar_ClosePtr.asFunction<void Function(VecCharPtr)>();
 
   CvStatus VecChar_Data(
     VecChar vec,
@@ -14774,7 +14748,7 @@ class CvNative {
       CvStatus Function(VecDMatch, int, ffi.Pointer<DMatch>)>();
 
   void VecDMatch_Close(
-    ffi.Pointer<VecDMatch> vec,
+    VecDMatchPtr vec,
   ) {
     return _VecDMatch_Close(
       vec,
@@ -14782,10 +14756,10 @@ class CvNative {
   }
 
   late final _VecDMatch_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecDMatch>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecDMatchPtr)>>(
           'VecDMatch_Close');
   late final _VecDMatch_Close =
-      _VecDMatch_ClosePtr.asFunction<void Function(ffi.Pointer<VecDMatch>)>();
+      _VecDMatch_ClosePtr.asFunction<void Function(VecDMatchPtr)>();
 
   CvStatus VecDMatch_New(
     ffi.Pointer<VecDMatch> rval,
@@ -14892,7 +14866,7 @@ class CvNative {
       CvStatus Function(VecDouble, int, ffi.Pointer<ffi.Double>)>();
 
   void VecDouble_Close(
-    ffi.Pointer<VecDouble> vec,
+    VecDoublePtr vec,
   ) {
     return _VecDouble_Close(
       vec,
@@ -14900,10 +14874,10 @@ class CvNative {
   }
 
   late final _VecDouble_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecDouble>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecDoublePtr)>>(
           'VecDouble_Close');
   late final _VecDouble_Close =
-      _VecDouble_ClosePtr.asFunction<void Function(ffi.Pointer<VecDouble>)>();
+      _VecDouble_ClosePtr.asFunction<void Function(VecDoublePtr)>();
 
   CvStatus VecDouble_Data(
     VecDouble vec,
@@ -15027,7 +15001,7 @@ class CvNative {
       CvStatus Function(VecFloat, int, ffi.Pointer<ffi.Float>)>();
 
   void VecFloat_Close(
-    ffi.Pointer<VecFloat> vec,
+    VecFloatPtr vec,
   ) {
     return _VecFloat_Close(
       vec,
@@ -15035,10 +15009,10 @@ class CvNative {
   }
 
   late final _VecFloat_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecFloat>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecFloatPtr)>>(
           'VecFloat_Close');
   late final _VecFloat_Close =
-      _VecFloat_ClosePtr.asFunction<void Function(ffi.Pointer<VecFloat>)>();
+      _VecFloat_ClosePtr.asFunction<void Function(VecFloatPtr)>();
 
   CvStatus VecFloat_Data(
     VecFloat vec,
@@ -15178,7 +15152,7 @@ class CvNative {
       CvStatus Function(VecInt, int, ffi.Pointer<ffi.Int>)>();
 
   void VecInt_Close(
-    ffi.Pointer<VecInt> vec,
+    VecIntPtr vec,
   ) {
     return _VecInt_Close(
       vec,
@@ -15186,10 +15160,9 @@ class CvNative {
   }
 
   late final _VecInt_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecInt>)>>(
-          'VecInt_Close');
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecIntPtr)>>('VecInt_Close');
   late final _VecInt_Close =
-      _VecInt_ClosePtr.asFunction<void Function(ffi.Pointer<VecInt>)>();
+      _VecInt_ClosePtr.asFunction<void Function(VecIntPtr)>();
 
   CvStatus VecInt_Data(
     VecInt vec,
@@ -15310,7 +15283,7 @@ class CvNative {
       CvStatus Function(VecKeyPoint, int, ffi.Pointer<KeyPoint>)>();
 
   void VecKeyPoint_Close(
-    ffi.Pointer<VecKeyPoint> vec,
+    VecKeyPointPtr vec,
   ) {
     return _VecKeyPoint_Close(
       vec,
@@ -15318,10 +15291,10 @@ class CvNative {
   }
 
   late final _VecKeyPoint_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecKeyPoint>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecKeyPointPtr)>>(
           'VecKeyPoint_Close');
-  late final _VecKeyPoint_Close = _VecKeyPoint_ClosePtr.asFunction<
-      void Function(ffi.Pointer<VecKeyPoint>)>();
+  late final _VecKeyPoint_Close =
+      _VecKeyPoint_ClosePtr.asFunction<void Function(VecKeyPointPtr)>();
 
   CvStatus VecKeyPoint_New(
     ffi.Pointer<VecKeyPoint> rval,
@@ -15427,7 +15400,7 @@ class CvNative {
       CvStatus Function(VecMat, int, ffi.Pointer<Mat>)>();
 
   void VecMat_Close(
-    ffi.Pointer<VecMat> vec,
+    VecMatPtr vec,
   ) {
     return _VecMat_Close(
       vec,
@@ -15435,10 +15408,9 @@ class CvNative {
   }
 
   late final _VecMat_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecMat>)>>(
-          'VecMat_Close');
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecMatPtr)>>('VecMat_Close');
   late final _VecMat_Close =
-      _VecMat_ClosePtr.asFunction<void Function(ffi.Pointer<VecMat>)>();
+      _VecMat_ClosePtr.asFunction<void Function(VecMatPtr)>();
 
   CvStatus VecMat_New(
     ffi.Pointer<VecMat> rval,
@@ -15541,7 +15513,7 @@ class CvNative {
       CvStatus Function(VecPoint2f, int, ffi.Pointer<Point2f>)>();
 
   void VecPoint2f_Close(
-    ffi.Pointer<VecPoint2f> vec,
+    VecPoint2fPtr vec,
   ) {
     return _VecPoint2f_Close(
       vec,
@@ -15549,10 +15521,10 @@ class CvNative {
   }
 
   late final _VecPoint2f_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecPoint2f>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecPoint2fPtr)>>(
           'VecPoint2f_Close');
   late final _VecPoint2f_Close =
-      _VecPoint2f_ClosePtr.asFunction<void Function(ffi.Pointer<VecPoint2f>)>();
+      _VecPoint2f_ClosePtr.asFunction<void Function(VecPoint2fPtr)>();
 
   CvStatus VecPoint2f_New(
     ffi.Pointer<VecPoint2f> rval,
@@ -15675,7 +15647,7 @@ class CvNative {
       CvStatus Function(VecPoint3f, int, ffi.Pointer<Point3f>)>();
 
   void VecPoint3f_Close(
-    ffi.Pointer<VecPoint3f> vec,
+    VecPoint3fPtr vec,
   ) {
     return _VecPoint3f_Close(
       vec,
@@ -15683,10 +15655,10 @@ class CvNative {
   }
 
   late final _VecPoint3f_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecPoint3f>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecPoint3fPtr)>>(
           'VecPoint3f_Close');
   late final _VecPoint3f_Close =
-      _VecPoint3f_ClosePtr.asFunction<void Function(ffi.Pointer<VecPoint3f>)>();
+      _VecPoint3f_ClosePtr.asFunction<void Function(VecPoint3fPtr)>();
 
   CvStatus VecPoint3f_New(
     ffi.Pointer<VecPoint3f> rval,
@@ -15809,7 +15781,7 @@ class CvNative {
       CvStatus Function(VecPoint, int, ffi.Pointer<Point>)>();
 
   void VecPoint_Close(
-    ffi.Pointer<VecPoint> vec,
+    VecPointPtr vec,
   ) {
     return _VecPoint_Close(
       vec,
@@ -15817,10 +15789,10 @@ class CvNative {
   }
 
   late final _VecPoint_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecPoint>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecPointPtr)>>(
           'VecPoint_Close');
   late final _VecPoint_Close =
-      _VecPoint_ClosePtr.asFunction<void Function(ffi.Pointer<VecPoint>)>();
+      _VecPoint_ClosePtr.asFunction<void Function(VecPointPtr)>();
 
   CvStatus VecPoint_New(
     ffi.Pointer<VecPoint> rval,
@@ -15941,7 +15913,7 @@ class CvNative {
       CvStatus Function(VecRect, int, ffi.Pointer<Rect>)>();
 
   void VecRect_Close(
-    ffi.Pointer<VecRect> vec,
+    VecRectPtr vec,
   ) {
     return _VecRect_Close(
       vec,
@@ -15949,10 +15921,10 @@ class CvNative {
   }
 
   late final _VecRect_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecRect>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecRectPtr)>>(
           'VecRect_Close');
   late final _VecRect_Close =
-      _VecRect_ClosePtr.asFunction<void Function(ffi.Pointer<VecRect>)>();
+      _VecRect_ClosePtr.asFunction<void Function(VecRectPtr)>();
 
   CvStatus VecRect_New(
     ffi.Pointer<VecRect> rval,
@@ -16074,7 +16046,7 @@ class CvNative {
       CvStatus Function(VecUChar, int, ffi.Pointer<uchar>)>();
 
   void VecUChar_Close(
-    ffi.Pointer<VecUChar> vec,
+    VecUCharPtr vec,
   ) {
     return _VecUChar_Close(
       vec,
@@ -16082,10 +16054,10 @@ class CvNative {
   }
 
   late final _VecUChar_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecUChar>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecUCharPtr)>>(
           'VecUChar_Close');
   late final _VecUChar_Close =
-      _VecUChar_ClosePtr.asFunction<void Function(ffi.Pointer<VecUChar>)>();
+      _VecUChar_ClosePtr.asFunction<void Function(VecUCharPtr)>();
 
   CvStatus VecUChar_Data(
     VecUChar vec,
@@ -16248,7 +16220,7 @@ class CvNative {
           ffi.Pointer<ffi.Int>)>();
 
   void VecVecChar_Close(
-    ffi.Pointer<VecVecChar> vec,
+    VecVecCharPtr vec,
   ) {
     return _VecVecChar_Close(
       vec,
@@ -16256,10 +16228,10 @@ class CvNative {
   }
 
   late final _VecVecChar_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecChar>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecVecCharPtr)>>(
           'VecVecChar_Close');
   late final _VecVecChar_Close =
-      _VecVecChar_ClosePtr.asFunction<void Function(ffi.Pointer<VecVecChar>)>();
+      _VecVecChar_ClosePtr.asFunction<void Function(VecVecCharPtr)>();
 
   CvStatus VecVecChar_New(
     ffi.Pointer<VecVecChar> rval,
@@ -16345,7 +16317,7 @@ class CvNative {
       CvStatus Function(VecVecDMatch, int, ffi.Pointer<VecDMatch>)>();
 
   void VecVecDMatch_Close(
-    ffi.Pointer<VecVecDMatch> vec,
+    VecVecDMatchPtr vec,
   ) {
     return _VecVecDMatch_Close(
       vec,
@@ -16353,10 +16325,10 @@ class CvNative {
   }
 
   late final _VecVecDMatch_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecDMatch>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecVecDMatchPtr)>>(
           'VecVecDMatch_Close');
-  late final _VecVecDMatch_Close = _VecVecDMatch_ClosePtr.asFunction<
-      void Function(ffi.Pointer<VecVecDMatch>)>();
+  late final _VecVecDMatch_Close =
+      _VecVecDMatch_ClosePtr.asFunction<void Function(VecVecDMatchPtr)>();
 
   CvStatus VecVecDMatch_Data(
     VecVecDMatch vec,
@@ -16480,18 +16452,18 @@ class CvNative {
       CvStatus Function(VecVecPoint2f, int, ffi.Pointer<VecPoint2f>)>();
 
   void VecVecPoint2f_Close(
-    ffi.Pointer<VecVecPoint2f> vec,
+    VecVecPoint2fPtr vec,
   ) {
     return _VecVecPoint2f_Close(
       vec,
     );
   }
 
-  late final _VecVecPoint2f_ClosePtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecPoint2f>)>>(
-      'VecVecPoint2f_Close');
-  late final _VecVecPoint2f_Close = _VecVecPoint2f_ClosePtr.asFunction<
-      void Function(ffi.Pointer<VecVecPoint2f>)>();
+  late final _VecVecPoint2f_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecVecPoint2fPtr)>>(
+          'VecVecPoint2f_Close');
+  late final _VecVecPoint2f_Close =
+      _VecVecPoint2f_ClosePtr.asFunction<void Function(VecVecPoint2fPtr)>();
 
   CvStatus VecVecPoint2f_New(
     ffi.Pointer<VecVecPoint2f> rval,
@@ -16599,18 +16571,18 @@ class CvNative {
       CvStatus Function(VecVecPoint3f, int, ffi.Pointer<VecPoint3f>)>();
 
   void VecVecPoint3f_Close(
-    ffi.Pointer<VecVecPoint3f> vec,
+    VecVecPoint3fPtr vec,
   ) {
     return _VecVecPoint3f_Close(
       vec,
     );
   }
 
-  late final _VecVecPoint3f_ClosePtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecPoint3f>)>>(
-      'VecVecPoint3f_Close');
-  late final _VecVecPoint3f_Close = _VecVecPoint3f_ClosePtr.asFunction<
-      void Function(ffi.Pointer<VecVecPoint3f>)>();
+  late final _VecVecPoint3f_ClosePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecVecPoint3fPtr)>>(
+          'VecVecPoint3f_Close');
+  late final _VecVecPoint3f_Close =
+      _VecVecPoint3f_ClosePtr.asFunction<void Function(VecVecPoint3fPtr)>();
 
   CvStatus VecVecPoint3f_New(
     ffi.Pointer<VecVecPoint3f> rval,
@@ -16718,7 +16690,7 @@ class CvNative {
       CvStatus Function(VecVecPoint, int, ffi.Pointer<VecPoint>)>();
 
   void VecVecPoint_Close(
-    ffi.Pointer<VecVecPoint> vec,
+    VecVecPointPtr vec,
   ) {
     return _VecVecPoint_Close(
       vec,
@@ -16726,10 +16698,10 @@ class CvNative {
   }
 
   late final _VecVecPoint_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecPoint>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VecVecPointPtr)>>(
           'VecVecPoint_Close');
-  late final _VecVecPoint_Close = _VecVecPoint_ClosePtr.asFunction<
-      void Function(ffi.Pointer<VecVecPoint>)>();
+  late final _VecVecPoint_Close =
+      _VecVecPoint_ClosePtr.asFunction<void Function(VecVecPointPtr)>();
 
   CvStatus VecVecPoint_New(
     ffi.Pointer<VecVecPoint> rval,
@@ -16801,7 +16773,7 @@ class CvNative {
       CvStatus Function(VecVecPoint, ffi.Pointer<ffi.Int>)>();
 
   void VideoCapture_Close(
-    ffi.Pointer<VideoCapture> self,
+    VideoCapturePtr self,
   ) {
     return _VideoCapture_Close(
       self,
@@ -16809,10 +16781,10 @@ class CvNative {
   }
 
   late final _VideoCapture_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VideoCapture>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VideoCapturePtr)>>(
           'VideoCapture_Close');
-  late final _VideoCapture_Close = _VideoCapture_ClosePtr.asFunction<
-      void Function(ffi.Pointer<VideoCapture>)>();
+  late final _VideoCapture_Close =
+      _VideoCapture_ClosePtr.asFunction<void Function(VideoCapturePtr)>();
 
   CvStatus VideoCapture_Get(
     VideoCapture self,
@@ -17057,7 +17029,7 @@ class CvNative {
       CvStatus Function(VideoCapture, int, double)>();
 
   void VideoWriter_Close(
-    ffi.Pointer<VideoWriter> self,
+    VideoWriterPtr self,
   ) {
     return _VideoWriter_Close(
       self,
@@ -17065,10 +17037,10 @@ class CvNative {
   }
 
   late final _VideoWriter_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VideoWriter>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(VideoWriterPtr)>>(
           'VideoWriter_Close');
-  late final _VideoWriter_Close = _VideoWriter_ClosePtr.asFunction<
-      void Function(ffi.Pointer<VideoWriter>)>();
+  late final _VideoWriter_Close =
+      _VideoWriter_ClosePtr.asFunction<void Function(VideoWriterPtr)>();
 
   CvStatus VideoWriter_Fourcc(
     int c1,
@@ -17298,7 +17270,7 @@ class CvNative {
       _WatershedPtr.asFunction<CvStatus Function(Mat, Mat)>();
 
   void WeChatQRCode_Close(
-    ffi.Pointer<WeChatQRCode> self,
+    WeChatQRCodePtr self,
   ) {
     return _WeChatQRCode_Close(
       self,
@@ -17306,10 +17278,10 @@ class CvNative {
   }
 
   late final _WeChatQRCode_ClosePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<WeChatQRCode>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(WeChatQRCodePtr)>>(
           'WeChatQRCode_Close');
-  late final _WeChatQRCode_Close = _WeChatQRCode_ClosePtr.asFunction<
-      void Function(ffi.Pointer<WeChatQRCode>)>();
+  late final _WeChatQRCode_Close =
+      _WeChatQRCode_ClosePtr.asFunction<void Function(WeChatQRCodePtr)>();
 
   CvStatus WeChatQRCode_DetectAndDecode(
     ffi.Pointer<WeChatQRCode> self,
@@ -17938,132 +17910,117 @@ class CvNative {
 class _SymbolAddresses {
   final CvNative _library;
   _SymbolAddresses(this._library);
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<AKAZE>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(AKAZEPtr)>>
       get AKAZE_Close => _library._AKAZE_ClosePtr;
-  ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<AgastFeatureDetector>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(AgastFeatureDetectorPtr)>>
       get AgastFeatureDetector_Close => _library._AgastFeatureDetector_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<AlignMTB>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(AlignMTBPtr)>>
       get AlignMTB_Close => _library._AlignMTB_ClosePtr;
-  ffi.Pointer<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<ArucoDetectorParameters>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ArucoDetectorParametersPtr)>>
       get ArucoDetectorParameters_Close =>
           _library._ArucoDetectorParameters_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ArucoDetector>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ArucoDetectorPtr)>>
       get ArucoDetector_Close => _library._ArucoDetector_ClosePtr;
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ArucoDictionary>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ArucoDictionaryPtr)>>
       get ArucoDictionary_Close => _library._ArucoDictionary_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<AsyncArray>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(AsyncArrayPtr)>>
       get AsyncArray_Close => _library._AsyncArray_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<BFMatcher>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(BFMatcherPtr)>>
       get BFMatcher_Close => _library._BFMatcher_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<BRISK>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(BRISKPtr)>>
       get BRISK_Close => _library._BRISK_ClosePtr;
-  ffi.Pointer<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<BackgroundSubtractorKNN>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(BackgroundSubtractorKNNPtr)>>
       get BackgroundSubtractorKNN_Close =>
           _library._BackgroundSubtractorKNN_ClosePtr;
   ffi.Pointer<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Pointer<BackgroundSubtractorMOG2>)>>
+          ffi.NativeFunction<ffi.Void Function(BackgroundSubtractorMOG2Ptr)>>
       get BackgroundSubtractorMOG2_Close =>
           _library._BackgroundSubtractorMOG2_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<BlockMeanHash>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(BlockMeanHashPtr)>>
       get BlockMeanHash_Close => _library._BlockMeanHash_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<CLAHE>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(CLAHEPtr)>>
       get CLAHE_Close => _library._CLAHE_ClosePtr;
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<CascadeClassifier>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(CascadeClassifierPtr)>>
       get CascadeClassifier_Close => _library._CascadeClassifier_ClosePtr;
-  ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<FastFeatureDetector>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(FastFeatureDetectorPtr)>>
       get FastFeatureDetector_Close => _library._FastFeatureDetector_ClosePtr;
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<FlannBasedMatcher>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(FlannBasedMatcherPtr)>>
       get FlannBasedMatcher_Close => _library._FlannBasedMatcher_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<GFTTDetector>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(GFTTDetectorPtr)>>
       get GFTTDetector_Close => _library._GFTTDetector_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<HOGDescriptor>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(HOGDescriptorPtr)>>
       get HOGDescriptor_Close => _library._HOGDescriptor_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<KAZE>)>>
-      get KAZE_Close => _library._KAZE_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<KalmanFilter>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(KAZEPtr)>> get KAZE_Close =>
+      _library._KAZE_ClosePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(KalmanFilterPtr)>>
       get KalmanFilter_Close => _library._KalmanFilter_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Layer>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(LayerPtr)>>
       get Layer_Close => _library._Layer_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MSER>)>>
-      get MSER_Close => _library._MSER_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Mat>)>>
-      get Mat_Close => _library._Mat_ClosePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(MSERPtr)>> get MSER_Close =>
+      _library._MSER_ClosePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(MatPtr)>> get Mat_Close =>
+      _library._Mat_ClosePtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
       get Mat_CloseVoid => _library._Mat_CloseVoidPtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MergeMertens>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(MergeMertensPtr)>>
       get MergeMertens_Close => _library._MergeMertens_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Net>)>>
-      get Net_Close => _library._Net_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ORB>)>>
-      get ORB_Close => _library._ORB_ClosePtr;
-  ffi.Pointer<
-          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<QRCodeDetector>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(NetPtr)>> get Net_Close =>
+      _library._Net_ClosePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ORBPtr)>> get ORB_Close =>
+      _library._ORB_ClosePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(QRCodeDetectorPtr)>>
       get QRCodeDetector_Close => _library._QRCodeDetector_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<RNG>)>>
-      get Rng_Close => _library._Rng_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<SIFT>)>>
-      get SIFT_Close => _library._SIFT_ClosePtr;
-  ffi.Pointer<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<SimpleBlobDetector>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(RNGPtr)>> get Rng_Close =>
+      _library._Rng_ClosePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(SIFTPtr)>> get SIFT_Close =>
+      _library._SIFT_ClosePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(SimpleBlobDetectorPtr)>>
       get SimpleBlobDetector_Close => _library._SimpleBlobDetector_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<PtrStitcher>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(PtrStitcherPtr)>>
       get Stitcher_Close => _library._Stitcher_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<Subdiv2D>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(Subdiv2DPtr)>>
       get Subdiv2D_Close => _library._Subdiv2D_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<TrackerMIL>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(TrackerMILPtr)>>
       get TrackerMIL_Close => _library._TrackerMIL_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecChar>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecCharPtr)>>
       get VecChar_Close => _library._VecChar_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecDMatch>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecDMatchPtr)>>
       get VecDMatch_Close => _library._VecDMatch_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecDouble>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecDoublePtr)>>
       get VecDouble_Close => _library._VecDouble_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecFloat>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecFloatPtr)>>
       get VecFloat_Close => _library._VecFloat_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecInt>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecIntPtr)>>
       get VecInt_Close => _library._VecInt_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecKeyPoint>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecKeyPointPtr)>>
       get VecKeyPoint_Close => _library._VecKeyPoint_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecMat>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecMatPtr)>>
       get VecMat_Close => _library._VecMat_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecPoint2f>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecPoint2fPtr)>>
       get VecPoint2f_Close => _library._VecPoint2f_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecPoint3f>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecPoint3fPtr)>>
       get VecPoint3f_Close => _library._VecPoint3f_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecPoint>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecPointPtr)>>
       get VecPoint_Close => _library._VecPoint_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecRect>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecRectPtr)>>
       get VecRect_Close => _library._VecRect_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecUChar>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecUCharPtr)>>
       get VecUChar_Close => _library._VecUChar_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecChar>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecVecCharPtr)>>
       get VecVecChar_Close => _library._VecVecChar_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecDMatch>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecVecDMatchPtr)>>
       get VecVecDMatch_Close => _library._VecVecDMatch_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecPoint2f>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecVecPoint2fPtr)>>
       get VecVecPoint2f_Close => _library._VecVecPoint2f_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecPoint3f>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecVecPoint3fPtr)>>
       get VecVecPoint3f_Close => _library._VecVecPoint3f_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VecVecPoint>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VecVecPointPtr)>>
       get VecVecPoint_Close => _library._VecVecPoint_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VideoCapture>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VideoCapturePtr)>>
       get VideoCapture_Close => _library._VideoCapture_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<VideoWriter>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(VideoWriterPtr)>>
       get VideoWriter_Close => _library._VideoWriter_ClosePtr;
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<WeChatQRCode>)>>
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(WeChatQRCodePtr)>>
       get WeChatQRCode_Close => _library._WeChatQRCode_ClosePtr;
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>
       get Window_Close => _library._Window_ClosePtr;
@@ -18230,8 +18187,6 @@ final class InputOutputArray extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
 
-typedef InputOutputArrayPtr = ffi.Pointer<InputOutputArray>;
-
 final class KAZE extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
@@ -18363,405 +18318,6 @@ final class Moment extends ffi.Struct {
 
   @ffi.Double()
   external double nu03;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_AKAZEPtr extends ffi.Struct {
-  external ffi.Pointer<AKAZEPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_AgastFeatureDetectorPtr extends ffi.Struct {
-  external ffi.Pointer<AgastFeatureDetectorPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_AlignMTBPtr extends ffi.Struct {
-  external ffi.Pointer<AlignMTBPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_ArucoDetectorParametersPtr extends ffi.Struct {
-  external ffi.Pointer<ArucoDetectorParametersPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_ArucoDetectorPtr extends ffi.Struct {
-  external ffi.Pointer<ArucoDetectorPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_ArucoDictionaryPtr extends ffi.Struct {
-  external ffi.Pointer<ArucoDictionaryPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_AsyncArrayPtr extends ffi.Struct {
-  external ffi.Pointer<AsyncArrayPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_BFMatcherPtr extends ffi.Struct {
-  external ffi.Pointer<BFMatcherPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_BRISKPtr extends ffi.Struct {
-  external ffi.Pointer<BRISKPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_BackgroundSubtractorKNNPtr extends ffi.Struct {
-  external ffi.Pointer<BackgroundSubtractorKNNPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_BackgroundSubtractorMOG2Ptr extends ffi.Struct {
-  external ffi.Pointer<BackgroundSubtractorMOG2Ptr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_BlockMeanHashPtr extends ffi.Struct {
-  external ffi.Pointer<BlockMeanHashPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_CLAHEPtr extends ffi.Struct {
-  external ffi.Pointer<CLAHEPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_CascadeClassifierPtr extends ffi.Struct {
-  external ffi.Pointer<CascadeClassifierPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_FastFeatureDetectorPtr extends ffi.Struct {
-  external ffi.Pointer<FastFeatureDetectorPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_FlannBasedMatcherPtr extends ffi.Struct {
-  external ffi.Pointer<FlannBasedMatcherPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_GFTTDetectorPtr extends ffi.Struct {
-  external ffi.Pointer<GFTTDetectorPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_HOGDescriptorPtr extends ffi.Struct {
-  external ffi.Pointer<HOGDescriptorPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_InputOutputArrayPtr extends ffi.Struct {
-  external ffi.Pointer<InputOutputArrayPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_KAZEPtr extends ffi.Struct {
-  external ffi.Pointer<KAZEPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_KalmanFilterPtr extends ffi.Struct {
-  external ffi.Pointer<KalmanFilterPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_LayerPtr extends ffi.Struct {
-  external ffi.Pointer<LayerPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_MSERPtr extends ffi.Struct {
-  external ffi.Pointer<MSERPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_MatPtr extends ffi.Struct {
-  external ffi.Pointer<MatPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_MergeMertensPtr extends ffi.Struct {
-  external ffi.Pointer<MergeMertensPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_NetPtr extends ffi.Struct {
-  external ffi.Pointer<NetPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_ORBPtr extends ffi.Struct {
-  external ffi.Pointer<ORBPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_PtrStitcherPtr extends ffi.Struct {
-  external ffi.Pointer<PtrStitcherPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_QRCodeDetectorPtr extends ffi.Struct {
-  external ffi.Pointer<QRCodeDetectorPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_RNGPtr extends ffi.Struct {
-  external ffi.Pointer<RNGPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_SIFTPtr extends ffi.Struct {
-  external ffi.Pointer<SIFTPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_SimpleBlobDetectorPtr extends ffi.Struct {
-  external ffi.Pointer<SimpleBlobDetectorPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_StitcherPtr extends ffi.Struct {
-  external ffi.Pointer<StitcherPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_Subdiv2DPtr extends ffi.Struct {
-  external ffi.Pointer<Subdiv2DPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_TrackerGOTURNPtr extends ffi.Struct {
-  external ffi.Pointer<TrackerGOTURNPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_TrackerMILPtr extends ffi.Struct {
-  external ffi.Pointer<TrackerMILPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_TrackerPtr extends ffi.Struct {
-  external ffi.Pointer<TrackerPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecCharPtr extends ffi.Struct {
-  external ffi.Pointer<VecCharPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecDMatchPtr extends ffi.Struct {
-  external ffi.Pointer<VecDMatchPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecDoublePtr extends ffi.Struct {
-  external ffi.Pointer<VecDoublePtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecFloatPtr extends ffi.Struct {
-  external ffi.Pointer<VecFloatPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecIntPtr extends ffi.Struct {
-  external ffi.Pointer<VecIntPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecKeyPointPtr extends ffi.Struct {
-  external ffi.Pointer<VecKeyPointPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecMatPtr extends ffi.Struct {
-  external ffi.Pointer<VecMatPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecPoint2fPtr extends ffi.Struct {
-  external ffi.Pointer<VecPoint2fPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecPoint3fPtr extends ffi.Struct {
-  external ffi.Pointer<VecPoint3fPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecPointPtr extends ffi.Struct {
-  external ffi.Pointer<VecPointPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecRectPtr extends ffi.Struct {
-  external ffi.Pointer<VecRectPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecUCharPtr extends ffi.Struct {
-  external ffi.Pointer<VecUCharPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecVecCharPtr extends ffi.Struct {
-  external ffi.Pointer<VecVecCharPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecVecDMatchPtr extends ffi.Struct {
-  external ffi.Pointer<VecVecDMatchPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecVecPoint2fPtr extends ffi.Struct {
-  external ffi.Pointer<VecVecPoint2fPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecVecPoint3fPtr extends ffi.Struct {
-  external ffi.Pointer<VecVecPoint3fPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VecVecPointPtr extends ffi.Struct {
-  external ffi.Pointer<VecVecPointPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VideoCapturePtr extends ffi.Struct {
-  external ffi.Pointer<VideoCapturePtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_VideoWriterPtr extends ffi.Struct {
-  external ffi.Pointer<VideoWriterPtr> p;
-}
-
-/// \
-/// Dart ffigen will not generate typedefs if not referred                                                  \
-/// so here we confirm they are included                                                                    \
-final class NO_USE_WeChatQRCodePtr extends ffi.Struct {
-  external ffi.Pointer<WeChatQRCodePtr> p;
 }
 
 final class Net extends ffi.Struct {
@@ -18975,8 +18531,6 @@ final class Stitcher extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
 
-typedef StitcherPtr = ffi.Pointer<Stitcher>;
-
 final class Subdiv2D extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
@@ -19002,14 +18556,11 @@ final class TrackerGOTURN extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
 
-typedef TrackerGOTURNPtr = ffi.Pointer<TrackerGOTURN>;
-
 final class TrackerMIL extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
 
 typedef TrackerMILPtr = ffi.Pointer<TrackerMIL>;
-typedef TrackerPtr = ffi.Pointer<Tracker>;
 
 final class Vec2b extends ffi.Struct {
   @uchar()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -114,7 +114,7 @@ CvStatus Mat_FromCMat(Mat m, Mat *rval)
   *rval = {new cv::Mat(m.ptr->clone())};
   END_WRAP
 }
-void Mat_Close(Mat *m)
+void Mat_Close(MatPtr m)
 {
   m->ptr->release();
   CVD_FREE(m)
@@ -1839,7 +1839,7 @@ CvStatus Rng_NewWithState(uint64_t state, RNG *rval)
   *rval = {new cv::RNG(state)};
   END_WRAP
 }
-void Rng_Close(RNG *rng){CVD_FREE(rng)}
+void Rng_Close(RNGPtr rng){CVD_FREE(rng)}
 
 CvStatus TheRNG(RNG *rval)
 {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -66,16 +66,6 @@ extern "C" {
 
 #define CVD_TYPECAST_C(value) reinterpret_cast<void *>(value);
 
-#define CVD_TYPEDEF_PTR(TYPE)                                                                                \
-  typedef TYPE *TYPE##Ptr;                                                                                   \
-  /**                                                                                                        \
-   * Dart ffigen will not generate typedefs if not referred                                                  \
-   * so here we confirm they are included                                                                    \
-   */                                                                                                        \
-  typedef struct {                                                                                           \
-    TYPE##Ptr *p;                                                                                            \
-  } NO_USE_##TYPE##Ptr;
-
 #ifdef __cplusplus
 #define CVD_TYPECAST_CPP(TYPE, value) reinterpret_cast<TYPE##_CPP>(value->ptr)
 #define CVD_FREE(value)                                                                                      \
@@ -88,7 +78,8 @@ extern "C" {
   typedef TYPE *NAME##_CPP;                                                                                  \
   typedef struct NAME {                                                                                      \
     TYPE *ptr;                                                                                               \
-  } NAME;
+  } NAME;                                                                                                    \
+  typedef NAME *NAME##Ptr;
 
 CVD_TYPEDEF(cv::Mat, Mat)
 CVD_TYPEDEF(cv::_InputOutputArray, InputOutputArray)
@@ -114,7 +105,8 @@ CVD_TYPEDEF(std::vector<std::vector<cv::DMatch>>, VecVecDMatch)
 #define CVD_TYPEDEF(TYPE, NAME)                                                                              \
   typedef struct NAME {                                                                                      \
     TYPE *ptr;                                                                                               \
-  } NAME;
+  } NAME;                                                                                                    \
+  typedef NAME *NAME##Ptr;
 
 typedef unsigned char  uchar;
 typedef unsigned short ushort;
@@ -140,10 +132,6 @@ CVD_TYPEDEF(void, VecKeyPoint)
 CVD_TYPEDEF(void, VecDMatch)
 CVD_TYPEDEF(void, VecVecDMatch)
 #endif
-
-CVD_TYPEDEF_PTR(Mat)
-CVD_TYPEDEF_PTR(InputOutputArray)
-CVD_TYPEDEF_PTR(RNG)
 
 // Wrapper for an individual cv::cvPoint
 typedef struct Point {
@@ -404,8 +392,8 @@ CvStatus RotatedRect_BoundingRect2f(RotatedRect rect, Rect2f *rval);
 // VecPoint2f vecPointToVecPoint2f(VecPoint src);
 
 typedef struct TermCriteria {
-  int type;
-  int maxCount;
+  int    type;
+  int    maxCount;
   double epsilon;
 } TermCriteria;
 
@@ -435,7 +423,7 @@ CvStatus Mat_NewFromVecPoint2f(VecPoint2f vec, Mat *rval);
 CvStatus Mat_NewFromVecPoint3f(VecPoint3f vec, Mat *rval);
 CvStatus Mat_FromPtr(Mat m, int rows, int cols, int type, int prows, int pcols, Mat *rval);
 CvStatus Mat_FromCMat(Mat m, Mat *rval);
-void     Mat_Close(Mat *m);
+void     Mat_Close(MatPtr m);
 void     Mat_CloseVoid(void *m);
 CvStatus Mat_Release(Mat *m);
 CvStatus Mat_Empty(Mat m, bool *rval);
@@ -699,7 +687,7 @@ CvStatus NormWithMats(Mat src1, Mat src2, int normType, double *rval);
 
 CvStatus Rng_New(RNG *rval);
 CvStatus Rng_NewWithState(uint64_t state, RNG *rval);
-void     Rng_Close(RNG *rng);
+void     Rng_Close(RNGPtr rng);
 CvStatus TheRNG(RNG *rval);
 CvStatus SetRNGSeed(int seed);
 CvStatus RNG_Fill(RNG rng, Mat mat, int distType, double a, double b, bool saturateRange);

--- a/src/core/vec.cpp
+++ b/src/core/vec.cpp
@@ -58,7 +58,7 @@ CvStatus VecPoint_Size(VecPoint vec, int *rval)
   END_WRAP
 }
 
-void VecPoint_Close(VecPoint *vec)
+void VecPoint_Close(VecPointPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -111,7 +111,7 @@ CvStatus VecVecPoint_Size(VecVecPoint vec, int *rval)
   END_WRAP
 }
 
-void VecVecPoint_Close(VecVecPoint *vec)
+void VecVecPoint_Close(VecVecPointPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -124,7 +124,7 @@ CvStatus VecPoint2f_New(VecPoint2f *rval)
   END_WRAP
 }
 
-void VecPoint2f_Close(VecPoint2f *vec)
+void VecPoint2f_Close(VecPoint2fPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -226,7 +226,7 @@ CvStatus VecVecPoint2f_Size(VecVecPoint2f vec, int *rval)
   END_WRAP
 }
 
-void VecVecPoint2f_Close(VecVecPoint2f *vec)
+void VecVecPoint2f_Close(VecVecPoint2fPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -239,7 +239,7 @@ CvStatus VecPoint3f_New(VecPoint3f *rval)
   END_WRAP
 }
 
-void VecPoint3f_Close(VecPoint3f *vec)
+void VecPoint3f_Close(VecPoint3fPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -341,7 +341,7 @@ CvStatus VecVecPoint3f_Size(VecVecPoint3f vec, int *rval)
   END_WRAP
 }
 
-void VecVecPoint3f_Close(VecVecPoint3f *vec)
+void VecVecPoint3f_Close(VecVecPoint3fPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -407,7 +407,7 @@ CvStatus VecUChar_Size(VecUChar vec, int *rval)
   END_WRAP
 }
 
-void VecUChar_Close(VecUChar *vec)
+void VecUChar_Close(VecUCharPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -477,7 +477,7 @@ CvStatus VecChar_ToString(VecChar vec, char **rval, int *length)
   END_WRAP
 }
 
-void VecChar_Close(VecChar *vec)
+void VecChar_Close(VecCharPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -533,7 +533,7 @@ CvStatus VecVecChar_Size(VecVecChar vec, int *rval)
   *rval = vec.ptr->size();
   END_WRAP
 }
-void VecVecChar_Close(VecVecChar *vec)
+void VecVecChar_Close(VecVecCharPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -599,7 +599,7 @@ CvStatus VecInt_Size(VecInt vec, int *rval)
   END_WRAP
 }
 
-void VecInt_Close(VecInt *vec)
+void VecInt_Close(VecIntPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -658,7 +658,7 @@ CvStatus VecFloat_Size(VecFloat vec, int *rval)
   END_WRAP
 }
 
-void VecFloat_Close(VecFloat *vec)
+void VecFloat_Close(VecFloatPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -717,7 +717,7 @@ CvStatus VecDouble_Size(VecDouble vec, int *rval)
   END_WRAP
 }
 
-void VecDouble_Close(VecDouble *vec)
+void VecDouble_Close(VecDoublePtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -769,7 +769,7 @@ CvStatus VecMat_Size(VecMat vec, int *rval)
   END_WRAP
 }
 
-void VecMat_Close(VecMat *vec)
+void VecMat_Close(VecMatPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -822,7 +822,7 @@ CvStatus VecRect_Size(VecRect vec, int *rval)
   END_WRAP
 }
 
-void VecRect_Close(VecRect *vec)
+void VecRect_Close(VecRectPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -876,7 +876,7 @@ CvStatus VecKeyPoint_Size(VecKeyPoint vec, int *rval)
   END_WRAP
 }
 
-void VecKeyPoint_Close(VecKeyPoint *vec)
+void VecKeyPoint_Close(VecKeyPointPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -930,7 +930,7 @@ CvStatus VecDMatch_Size(VecDMatch vec, int *rval)
   END_WRAP
 }
 
-void VecDMatch_Close(VecDMatch *vec)
+void VecDMatch_Close(VecDMatchPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)
@@ -990,7 +990,7 @@ CvStatus VecVecDMatch_Size(VecVecDMatch vec, int *rval)
   END_WRAP
 }
 
-void VecVecDMatch_Close(VecVecDMatch *vec)
+void VecVecDMatch_Close(VecVecDMatchPtr vec)
 {
   vec->ptr->clear();
   CVD_FREE(vec)

--- a/src/core/vec.h
+++ b/src/core/vec.h
@@ -11,48 +11,6 @@
 extern "C" {
 #endif
 
-CVD_TYPEDEF_PTR(VecUChar)
-CVD_TYPEDEF_PTR(VecChar)
-CVD_TYPEDEF_PTR(VecVecChar)
-CVD_TYPEDEF_PTR(VecInt)
-CVD_TYPEDEF_PTR(VecFloat)
-CVD_TYPEDEF_PTR(VecDouble)
-CVD_TYPEDEF_PTR(VecPoint)
-CVD_TYPEDEF_PTR(VecVecPoint)
-CVD_TYPEDEF_PTR(VecPoint2f)
-CVD_TYPEDEF_PTR(VecVecPoint2f)
-CVD_TYPEDEF_PTR(VecPoint3f)
-CVD_TYPEDEF_PTR(VecVecPoint3f)
-CVD_TYPEDEF_PTR(VecMat)
-CVD_TYPEDEF_PTR(VecRect)
-CVD_TYPEDEF_PTR(VecKeyPoint)
-CVD_TYPEDEF_PTR(VecDMatch)
-CVD_TYPEDEF_PTR(VecVecDMatch)
-
-/**
- * Dart ffigen will not generate typedefs if not referred
- * so here we confirm they are included
- */
-// typedef struct USED_TO_INCLUDE_VECPTR {
-//   VecUCharPtr      p0;
-//   VecCharPtr       p1;
-//   VecVecCharPtr    p2;
-//   VecIntPtr        p3;
-//   VecFloatPtr      p4;
-//   VecDoublePtr     p5;
-//   VecPointPtr      p6;
-//   VecVecPointPtr   p7;
-//   VecPoint2fPtr    p8;
-//   VecVecPoint2fPtr p9;
-//   VecPoint3fPtr    p10;
-//   VecVecPoint3fPtr p11;
-//   VecMatPtr        p12;
-//   VecRectPtr       p13;
-//   VecKeyPointPtr   p14;
-//   VecDMatchPtr     p15;
-//   VecVecDMatchPtr  p16;
-// } USED_TO_INCLUDE_VECPTR;
-
 CvStatus VecPoint_New(VecPoint *rval);
 /**
  * Copy from a pointer
@@ -64,7 +22,7 @@ CvStatus VecPoint_At(VecPoint vec, int idx, Point *rval);
 // CvStatus VecPoint_Data(VecPoint vec, Point **rval);
 CvStatus VecPoint_Append(VecPoint vec, Point p);
 CvStatus VecPoint_Size(VecPoint vec, int *rval);
-void     VecPoint_Close(VecPoint *vec);
+void     VecPoint_Close(VecPointPtr vec);
 
 CvStatus VecVecPoint_New(VecVecPoint *rval);
 CvStatus VecVecPoint_NewFromPointer(VecPoint *points, int length, VecVecPoint *rval);
@@ -73,7 +31,7 @@ CvStatus VecVecPoint_At(VecVecPoint vec, int idx, VecPoint *rval);
 // CvStatus VecVecPoint_Data(VecVecPoint vec, VecPoint **rval);
 CvStatus VecVecPoint_Append(VecVecPoint vec, VecPoint pv);
 CvStatus VecVecPoint_Size(VecVecPoint vec, int *rval);
-void     VecVecPoint_Close(VecVecPoint *vec);
+void     VecVecPoint_Close(VecVecPointPtr vec);
 
 CvStatus VecPoint2f_New(VecPoint2f *rval);
 CvStatus VecPoint2f_NewFromPointer(Point2f *pts, int length, VecPoint2f *rval);
@@ -83,7 +41,7 @@ CvStatus VecPoint2f_At(VecPoint2f vec, int idx, Point2f *rval);
 // CvStatus VecPoint2f_Data(VecPoint2f vec, Point2f **rval);
 CvStatus VecPoint2f_Append(VecPoint2f vec, Point2f p);
 CvStatus VecPoint2f_Size(VecPoint2f vec, int *rval);
-void     VecPoint2f_Close(VecPoint2f *vec);
+void     VecPoint2f_Close(VecPoint2fPtr vec);
 
 CvStatus VecVecPoint2f_New(VecVecPoint2f *rval);
 CvStatus VecVecPoint2f_NewFromPointer(VecPoint2f *points, int length, VecVecPoint2f *rval);
@@ -92,7 +50,7 @@ CvStatus VecVecPoint2f_Size(VecVecPoint2f vec, int *rval);
 CvStatus VecVecPoint2f_At(VecVecPoint2f vec, int idx, VecPoint2f *rval);
 // CvStatus VecVecPoint2f_Data(VecVecPoint2f vec, VecPoint2f **rval);
 CvStatus VecVecPoint2f_Append(VecVecPoint2f vec, VecPoint2f pv);
-void     VecVecPoint2f_Close(VecVecPoint2f *vec);
+void     VecVecPoint2f_Close(VecVecPoint2fPtr vec);
 
 CvStatus VecPoint3f_New(VecPoint3f *rval);
 CvStatus VecPoint3f_NewFromPointer(Point3f *points, int length, VecPoint3f *rval);
@@ -102,7 +60,7 @@ CvStatus VecPoint3f_Append(VecPoint3f vec, Point3f point);
 CvStatus VecPoint3f_At(VecPoint3f vec, int idx, Point3f *rval);
 // CvStatus VecPoint3f_Data(VecPoint3f vec, Point3f **rval);
 CvStatus VecPoint3f_Size(VecPoint3f vec, int *rval);
-void     VecPoint3f_Close(VecPoint3f *vec);
+void     VecPoint3f_Close(VecPoint3fPtr vec);
 
 CvStatus VecVecPoint3f_New(VecVecPoint3f *rval);
 CvStatus VecVecPoint3f_NewFromPointer(VecPoint3f *points, int length, VecVecPoint3f *rval);
@@ -111,7 +69,7 @@ CvStatus VecVecPoint3f_Size(VecVecPoint3f vec, int *rval);
 CvStatus VecVecPoint3f_At(VecVecPoint3f vec, int idx, VecPoint3f *rval);
 // CvStatus VecVecPoint3f_Data(VecVecPoint3f vec, VecPoint3f **rval);
 CvStatus VecVecPoint3f_Append(VecVecPoint3f vec, VecPoint3f pv);
-void     VecVecPoint3f_Close(VecVecPoint3f *vec);
+void     VecVecPoint3f_Close(VecVecPoint3fPtr vec);
 
 CvStatus VecUChar_New(VecUChar *rval);
 CvStatus VecUChar_NewFromPointer(uchar *p, int length, VecUChar *rval);
@@ -121,7 +79,7 @@ CvStatus VecUChar_At(VecUChar vec, int idx, uchar *rval);
 CvStatus VecUChar_Data(VecUChar vec, uchar **rval);
 CvStatus VecUChar_AtNoBoundCheck(VecUChar vec, int idx, uchar *rval);
 CvStatus VecUChar_Size(VecUChar vec, int *rval);
-void     VecUChar_Close(VecUChar *vec);
+void     VecUChar_Close(VecUCharPtr vec);
 
 CvStatus VecChar_New(VecChar *rval);
 CvStatus VecChar_NewFromPointer(const char *p, int length, VecChar *rval);
@@ -131,7 +89,7 @@ CvStatus VecChar_At(VecChar vec, int idx, char *rval);
 CvStatus VecChar_Data(VecChar vec, char **rval);
 CvStatus VecChar_Size(VecChar vec, int *rval);
 CvStatus VecChar_ToString(VecChar vec, char **rval, int *length);
-void     VecChar_Close(VecChar *vec);
+void     VecChar_Close(VecCharPtr vec);
 
 CvStatus VecVecChar_New(VecVecChar *rval);
 CvStatus VecVecChar_NewFromVec(VecVecChar vec, VecVecChar *rval);
@@ -141,7 +99,7 @@ CvStatus VecVecChar_At(VecVecChar vec, int idx, VecChar *rval);
 // CvStatus VecVecChar_Data(VecVecChar vec, VecChar **rval);
 CvStatus VecVecChar_At_Str(VecVecChar vec, int idx, char **rval, int *length);
 CvStatus VecVecChar_Size(VecVecChar vec, int *rval);
-void     VecVecChar_Close(VecVecChar *vec);
+void     VecVecChar_Close(VecVecCharPtr vec);
 
 CvStatus VecInt_New(VecInt *rval);
 /**
@@ -154,7 +112,7 @@ CvStatus VecInt_At(VecInt vec, int idx, int *rval);
 CvStatus VecInt_AtNoBoundCheck(VecInt vec, int idx, int *rval);
 CvStatus VecInt_Data(VecInt vec, int **rval);
 CvStatus VecInt_Size(VecInt vec, int *rval);
-void     VecInt_Close(VecInt *vec);
+void     VecInt_Close(VecIntPtr vec);
 
 CvStatus VecFloat_New(VecFloat *rval);
 CvStatus VecFloat_NewFromPointer(float *p, int length, VecFloat *rval);
@@ -163,7 +121,7 @@ CvStatus VecFloat_Append(VecFloat vec, float f);
 CvStatus VecFloat_At(VecFloat vec, int idx, float *rval);
 CvStatus VecFloat_Data(VecFloat vec, float **rval);
 CvStatus VecFloat_Size(VecFloat vec, int *rval);
-void     VecFloat_Close(VecFloat *vec);
+void     VecFloat_Close(VecFloatPtr vec);
 
 CvStatus VecDouble_New(VecDouble *rval);
 CvStatus VecDouble_NewFromPointer(double *p, int length, VecDouble *rval);
@@ -172,7 +130,7 @@ CvStatus VecDouble_Append(VecDouble vec, double d);
 CvStatus VecDouble_At(VecDouble vec, int idx, double *rval);
 CvStatus VecDouble_Data(VecDouble vec, double **rval);
 CvStatus VecDouble_Size(VecDouble vec, int *rval);
-void     VecDouble_Close(VecDouble *vec);
+void     VecDouble_Close(VecDoublePtr vec);
 
 CvStatus VecMat_New(VecMat *rval);
 CvStatus VecMat_NewFromPointer(Mat *mats, int length, VecMat *rval);
@@ -181,7 +139,7 @@ CvStatus VecMat_Append(VecMat vec, Mat mat);
 CvStatus VecMat_At(VecMat vec, int i, Mat *rval);
 // CvStatus VecMat_Data(VecMat vec, Mat **rval);
 CvStatus VecMat_Size(VecMat vec, int *rval);
-void     VecMat_Close(VecMat *vec);
+void     VecMat_Close(VecMatPtr vec);
 
 CvStatus VecRect_New(VecRect *rval);
 CvStatus VecRect_NewFromPointer(Rect *rects, int length, VecRect *rval);
@@ -190,7 +148,7 @@ CvStatus VecRect_At(VecRect vec, int idx, Rect *rval);
 // CvStatus VecRect_Data(VecRect vec, Rect **rval);
 CvStatus VecRect_Append(VecRect vec, Rect rect);
 CvStatus VecRect_Size(VecRect vec, int *rval);
-void     VecRect_Close(VecRect *vec);
+void     VecRect_Close(VecRectPtr vec);
 
 CvStatus VecKeyPoint_New(VecKeyPoint *rval);
 CvStatus VecKeyPoint_NewFromPointer(KeyPoint *keypoints, int length, VecKeyPoint *rval);
@@ -199,7 +157,7 @@ CvStatus VecKeyPoint_Append(VecKeyPoint vec, KeyPoint kp);
 CvStatus VecKeyPoint_At(VecKeyPoint vec, int idx, KeyPoint *rval);
 // CvStatus VecKeyPoint_Data(VecKeyPoint vec, KeyPoint **rval);
 CvStatus VecKeyPoint_Size(VecKeyPoint vec, int *rval);
-void     VecKeyPoint_Close(VecKeyPoint *vec);
+void     VecKeyPoint_Close(VecKeyPointPtr vec);
 
 CvStatus VecDMatch_New(VecDMatch *rval);
 CvStatus VecDMatch_NewFromPointer(DMatch *matches, int length, VecDMatch *rval);
@@ -208,7 +166,7 @@ CvStatus VecDMatch_Append(VecDMatch vec, DMatch dm);
 CvStatus VecDMatch_At(VecDMatch vec, int idx, DMatch *rval);
 // CvStatus VecDMatch_Data(VecDMatch vec, DMatch **rval);
 CvStatus VecDMatch_Size(VecDMatch vec, int *rval);
-void     VecDMatch_Close(VecDMatch *vec);
+void     VecDMatch_Close(VecDMatchPtr vec);
 
 CvStatus VecVecDMatch_New(VecVecDMatch *rval);
 CvStatus VecVecDMatch_NewFromPointer(VecDMatch *matches, int length, VecVecDMatch *rval);
@@ -217,7 +175,7 @@ CvStatus VecVecDMatch_At(VecVecDMatch vec, int idx, VecDMatch *rval);
 CvStatus VecVecDMatch_Data(VecVecDMatch vec, VecDMatch **rval);
 CvStatus VecVecDMatch_Append(VecVecDMatch vec, VecDMatch dm);
 CvStatus VecVecDMatch_Size(VecVecDMatch vec, int *rval);
-void     VecVecDMatch_Close(VecVecDMatch *vec);
+void     VecVecDMatch_Close(VecVecDMatchPtr vec);
 
 #ifdef __cplusplus
 }

--- a/src/dnn/asyncarray.cpp
+++ b/src/dnn/asyncarray.cpp
@@ -18,7 +18,7 @@ CvStatus AsyncArray_New(AsyncArray *rval)
 }
 
 // AsyncArray_Close deletes an existing AsyncArray
-void AsyncArray_Close(AsyncArray *a)
+void AsyncArray_Close(AsyncArrayPtr a)
 {
   CVD_FREE(a)
 }

--- a/src/dnn/asyncarray.h
+++ b/src/dnn/asyncarray.h
@@ -11,7 +11,6 @@
 extern "C" {
 #endif
 
-#include "core/core.h"
 #include "dnn.h"
 
 #ifdef __cplusplus
@@ -20,12 +19,10 @@ CVD_TYPEDEF(cv::AsyncArray, AsyncArray);
 CVD_TYPEDEF(void, AsyncArray)
 #endif
 
-CVD_TYPEDEF_PTR(AsyncArray)
-
 CvStatus AsyncArray_New(AsyncArray *rval);
 CvStatus AsyncArray_Get(AsyncArray async_out, Mat out);
 CvStatus Net_forwardAsync(Net net, const char *outputName, AsyncArray *rval);
-void     AsyncArray_Close(AsyncArray *a);
+void     AsyncArray_Close(AsyncArrayPtr a);
 
 #ifdef __cplusplus
 }

--- a/src/dnn/dnn.cpp
+++ b/src/dnn/dnn.cpp
@@ -89,7 +89,7 @@ CvStatus Net_ReadNetFromONNXBytes(VecUChar model, Net *rval)
   END_WRAP
 }
 
-void Net_Close(Net *net){CVD_FREE(net)}
+void Net_Close(NetPtr net){CVD_FREE(net)}
 
 CvStatus Net_BlobFromImage(Mat image, Mat blob, double scalefactor, Size size, Scalar mean, bool swapRB,
                            bool crop, int ddepth)
@@ -277,7 +277,7 @@ CvStatus Layer_GetType(Layer layer, char **rval)
   END_WRAP
 }
 
-void Layer_Close(Layer *layer){CVD_FREE(layer)}
+void Layer_Close(LayerPtr layer){CVD_FREE(layer)}
 
 CvStatus
     NMSBoxes(VecRect bboxes, VecFloat scores, float score_threshold, float nms_threshold, VecInt *indices)

--- a/src/dnn/dnn.h
+++ b/src/dnn/dnn.h
@@ -27,9 +27,6 @@ CVD_TYPEDEF(void, Net)
 CVD_TYPEDEF(void, Layer)
 #endif
 
-CVD_TYPEDEF_PTR(Net)
-CVD_TYPEDEF_PTR(Layer)
-
 CvStatus Net_Create(CVD_OUT Net *rval);
 CvStatus Net_FromNet(Net net, CVD_OUT Net *rval);
 CvStatus Net_ReadNet(const char *model, const char *config, const char *framework, CVD_OUT Net *rval);
@@ -43,7 +40,7 @@ CvStatus Net_ReadNetFromTFLiteBytes(VecUChar bufferModel, CVD_OUT Net *rval);
 CvStatus Net_ReadNetFromTorch(const char *model, bool isBinary, bool evaluate, CVD_OUT Net *rval);
 CvStatus Net_ReadNetFromONNX(const char *model, CVD_OUT Net *rval);
 CvStatus Net_ReadNetFromONNXBytes(VecUChar model, CVD_OUT Net *rval);
-void     Net_Close(Net *net);
+void     Net_Close(NetPtr net);
 
 CvStatus Net_BlobFromImage(Mat image, CVD_OUT Mat blob, double scalefactor, Size size, Scalar mean,
                            bool swapRB, bool crop, int ddepth);
@@ -70,7 +67,7 @@ CvStatus Layer_InputNameToIndex(Layer layer, const char *name, CVD_OUT int *rval
 CvStatus Layer_OutputNameToIndex(Layer layer, const char *name, CVD_OUT int *rval);
 CvStatus Layer_GetName(Layer layer, CVD_OUT char **rval);
 CvStatus Layer_GetType(Layer layer, CVD_OUT char **rval);
-void     Layer_Close(Layer *layer);
+void     Layer_Close(LayerPtr layer);
 
 CvStatus NMSBoxes(VecRect bboxes, VecFloat scores, float score_threshold, float nms_threshold,
                   CVD_OUT VecInt *indices);

--- a/src/extra/aruco.cpp
+++ b/src/extra/aruco.cpp
@@ -13,7 +13,7 @@ CvStatus ArucoDetectorParameters_Create(ArucoDetectorParameters *rval)
   *rval = {new cv::aruco::DetectorParameters()};
   END_WRAP
 }
-void ArucoDetectorParameters_Close(ArucoDetectorParameters *ap){CVD_FREE(ap)}
+void ArucoDetectorParameters_Close(ArucoDetectorParametersPtr ap){CVD_FREE(ap)}
 
 CvStatus ArucoDetectorParameters_SetAdaptiveThreshWinSizeMin(ArucoDetectorParameters ap,
                                                              int                     adaptiveThreshWinSizeMin)
@@ -394,7 +394,7 @@ CvStatus getPredefinedDictionary(int dictionaryId, ArucoDictionary *rval)
   *rval = {new cv::aruco::Dictionary(cv::aruco::getPredefinedDictionary(dictionaryId))};
   END_WRAP
 }
-void ArucoDictionary_Close(ArucoDictionary *self){CVD_FREE(self)}
+void ArucoDictionary_Close(ArucoDictionaryPtr self){CVD_FREE(self)}
 
 CvStatus ArucoDetector_New(ArucoDetector *rval)
 {
@@ -409,7 +409,7 @@ CvStatus ArucoDetector_NewWithParams(ArucoDictionary dictionary, ArucoDetectorPa
   *rval = {new cv::aruco::ArucoDetector(*dictionary.ptr, *params.ptr)};
   END_WRAP
 }
-void ArucoDetector_Close(ArucoDetector *ad){CVD_FREE(ad)}
+void ArucoDetector_Close(ArucoDetectorPtr ad){CVD_FREE(ad)}
 
 CvStatus ArucoDetector_DetectMarkers(ArucoDetector ad, Mat inputArr, VecVecPoint2f *markerCorners,
                                      VecInt *markerIds, VecVecPoint2f *rejectedCandidates)

--- a/src/extra/aruco.h
+++ b/src/extra/aruco.h
@@ -26,12 +26,8 @@ CVD_TYPEDEF(void, ArucoDetectorParameters)
 CVD_TYPEDEF(void, ArucoDetector)
 #endif
 
-CVD_TYPEDEF_PTR(ArucoDictionary)
-CVD_TYPEDEF_PTR(ArucoDetectorParameters)
-CVD_TYPEDEF_PTR(ArucoDetector)
-
 CvStatus ArucoDetectorParameters_Create(ArucoDetectorParameters *rval);
-void     ArucoDetectorParameters_Close(ArucoDetectorParameters *ap);
+void     ArucoDetectorParameters_Close(ArucoDetectorParametersPtr ap);
 CvStatus ArucoDetectorParameters_SetAdaptiveThreshWinSizeMin(ArucoDetectorParameters ap,
                                                              int adaptiveThreshWinSizeMin);
 CvStatus ArucoDetectorParameters_GetAdaptiveThreshWinSizeMin(ArucoDetectorParameters ap, int *rval);
@@ -116,12 +112,12 @@ CvStatus ArucoDetectorParameters_SetDetectInvertedMarker(ArucoDetectorParameters
 CvStatus ArucoDetectorParameters_GetDetectInvertedMarker(ArucoDetectorParameters ap, bool *rval);
 
 CvStatus getPredefinedDictionary(int dictionaryId, ArucoDictionary *rval);
-void     ArucoDictionary_Close(ArucoDictionary *self);
+void     ArucoDictionary_Close(ArucoDictionaryPtr self);
 
 CvStatus ArucoDetector_New(ArucoDetector *rval);
 CvStatus ArucoDetector_NewWithParams(ArucoDictionary dictionary, ArucoDetectorParameters params,
                                      ArucoDetector *rval);
-void     ArucoDetector_Close(ArucoDetector *ad);
+void     ArucoDetector_Close(ArucoDetectorPtr ad);
 CvStatus ArucoDetector_DetectMarkers(ArucoDetector ad, Mat inputArr, VecVecPoint2f *markerCorners,
                                      VecInt *markerIds, VecVecPoint2f *rejectedCandidates);
 

--- a/src/extra/img_hash.cpp
+++ b/src/extra/img_hash.cpp
@@ -45,7 +45,7 @@ CvStatus BlockMeanHash_SetMode(BlockMeanHash self, int mode)
   BEGIN_WRAP(*self.ptr)->setMode(mode);
   END_WRAP
 }
-void BlockMeanHash_Close(BlockMeanHash *self){CVD_FREE(self)}
+void BlockMeanHash_Close(BlockMeanHashPtr self){CVD_FREE(self)}
 
 CvStatus BlockMeanHash_Compute(BlockMeanHash self, Mat inputArr, Mat outputArr)
 {

--- a/src/extra/img_hash.h
+++ b/src/extra/img_hash.h
@@ -31,8 +31,6 @@ CVD_TYPEDEF(void, BlockMeanHash)
 // typedef void *RadialVarianceHash;
 #endif
 
-CVD_TYPEDEF_PTR(BlockMeanHash)
-
 enum {
   /** use fewer block and generate 16*16/8 uchar hash value */
   BLOCK_MEAN_HASH_MODE_0 = 0,
@@ -49,7 +47,7 @@ CvStatus averageHashCompare(Mat a, Mat b, double *rval);
 CvStatus BlockMeanHash_Create(int mode, BlockMeanHash *rval);
 CvStatus BlockMeanHash_GetMean(BlockMeanHash self, double **rval, int *length);
 CvStatus BlockMeanHash_SetMode(BlockMeanHash self, int mode);
-void     BlockMeanHash_Close(BlockMeanHash *self);
+void     BlockMeanHash_Close(BlockMeanHashPtr self);
 CvStatus BlockMeanHash_Compute(BlockMeanHash self, Mat inputArr, Mat outputArr);
 CvStatus BlockMeanHash_Compare(BlockMeanHash self, Mat hashOne, Mat hashTwo, double *rval);
 CvStatus blockMeanHashCompute(Mat inputArr, Mat outputArr, int mode);

--- a/src/extra/wechat_qrcode.cpp
+++ b/src/extra/wechat_qrcode.cpp
@@ -17,7 +17,7 @@ CvStatus WeChatQRCode_NewWithParams(const char *detector_prototxt_path, const ch
                                                  super_resolution_caffe_model_path)};
   END_WRAP
 }
-void WeChatQRCode_Close(WeChatQRCode *self)
+void WeChatQRCode_Close(WeChatQRCodePtr self)
 {
   delete self->ptr;
   self->ptr = nullptr;

--- a/src/extra/wechat_qrcode.h
+++ b/src/extra/wechat_qrcode.h
@@ -21,13 +21,11 @@ CVD_TYPEDEF(cv::wechat_qrcode::WeChatQRCode, WeChatQRCode)
 CVD_TYPEDEF(void, WeChatQRCode)
 #endif
 
-CVD_TYPEDEF_PTR(WeChatQRCode)
-
 CvStatus WeChatQRCode_New(WeChatQRCode *qrcode);
 CvStatus WeChatQRCode_NewWithParams(const char *detector_prototxt_path, const char *detector_caffe_model_path,
                                     const char *super_resolution_prototxt_path,
                                     const char *super_resolution_caffe_model_path, WeChatQRCode *qrcode);
-void     WeChatQRCode_Close(WeChatQRCode *self);
+void     WeChatQRCode_Close(WeChatQRCodePtr self);
 CvStatus WeChatQRCode_DetectAndDecode(WeChatQRCode *self, Mat img, VecMat *points, VecVecChar *rval);
 CvStatus WeChatQRCode_GetScaleFactor(WeChatQRCode *self, float *rval);
 CvStatus WeChatQRCode_SetScaleFactor(WeChatQRCode *self, float scale_factor);

--- a/src/features2d/features2d.cpp
+++ b/src/features2d/features2d.cpp
@@ -14,7 +14,7 @@ CvStatus AKAZE_Create(AKAZE *rval)
   *rval = {new cv::Ptr<cv::AKAZE>(cv::AKAZE::create())};
   END_WRAP
 }
-void AKAZE_Close(AKAZE *a){CVD_FREE(a)}
+void AKAZE_Close(AKAZEPtr a){CVD_FREE(a)}
 
 CvStatus AKAZE_Detect(AKAZE a, Mat src, VecKeyPoint *rval)
 {
@@ -39,7 +39,7 @@ CvStatus AgastFeatureDetector_Create(AgastFeatureDetector *rval)
   *rval = {new cv::Ptr<cv::AgastFeatureDetector>(cv::AgastFeatureDetector::create())};
   END_WRAP
 }
-void AgastFeatureDetector_Close(AgastFeatureDetector *a){CVD_FREE(a)}
+void AgastFeatureDetector_Close(AgastFeatureDetectorPtr a){CVD_FREE(a)}
 
 CvStatus AgastFeatureDetector_Detect(AgastFeatureDetector a, Mat src, VecKeyPoint *rval)
 {
@@ -56,7 +56,7 @@ CvStatus BRISK_Create(BRISK *rval)
   *rval = {new cv::Ptr<cv::BRISK>(cv::BRISK::create())};
   END_WRAP
 }
-void BRISK_Close(BRISK *b){CVD_FREE(b)}
+void BRISK_Close(BRISKPtr b){CVD_FREE(b)}
 
 CvStatus BRISK_Detect(BRISK b, Mat src, VecKeyPoint *rval)
 {
@@ -90,7 +90,7 @@ CvStatus FastFeatureDetector_CreateWithParams(int threshold, bool nonmaxSuppress
       cv::FastFeatureDetector::create(threshold, nonmaxSuppression, type_))};
   END_WRAP
 }
-void FastFeatureDetector_Close(FastFeatureDetector *f){CVD_FREE(f)}
+void FastFeatureDetector_Close(FastFeatureDetectorPtr f){CVD_FREE(f)}
 
 CvStatus FastFeatureDetector_Detect(FastFeatureDetector f, Mat src, VecKeyPoint *rval)
 {
@@ -107,7 +107,7 @@ CvStatus GFTTDetector_Create(GFTTDetector *rval)
   *rval = {new cv::Ptr<cv::GFTTDetector>(cv::GFTTDetector::create())};
   END_WRAP
 }
-void GFTTDetector_Close(GFTTDetector *a){CVD_FREE(a)}
+void GFTTDetector_Close(GFTTDetectorPtr a){CVD_FREE(a)}
 
 CvStatus GFTTDetector_Detect(GFTTDetector a, Mat src, VecKeyPoint *rval)
 {
@@ -124,7 +124,7 @@ CvStatus KAZE_Create(KAZE *rval)
   *rval = {new cv::Ptr<cv::KAZE>(cv::KAZE::create())};
   END_WRAP
 }
-void KAZE_Close(KAZE *a){CVD_FREE(a)}
+void KAZE_Close(KAZEPtr a){CVD_FREE(a)}
 
 CvStatus KAZE_Detect(KAZE a, Mat src, VecKeyPoint *rval)
 {
@@ -149,7 +149,7 @@ CvStatus MSER_Create(MSER *rval)
   *rval = {new cv::Ptr<cv::MSER>(cv::MSER::create())};
   END_WRAP
 }
-void MSER_Close(MSER *a){CVD_FREE(a)}
+void MSER_Close(MSERPtr a){CVD_FREE(a)}
 
 CvStatus MSER_Detect(MSER a, Mat src, VecKeyPoint *rval)
 {
@@ -176,7 +176,7 @@ CvStatus ORB_CreateWithParams(int nfeatures, float scaleFactor, int nlevels, int
                                                 WTA_K, type, patchSize, fastThreshold))};
   END_WRAP
 }
-void ORB_Close(ORB *o){CVD_FREE(o)}
+void ORB_Close(ORBPtr o){CVD_FREE(o)}
 
 CvStatus ORB_Detect(ORB o, Mat src, VecKeyPoint *rval)
 {
@@ -262,7 +262,7 @@ CvStatus SimpleBlobDetector_Create_WithParams(SimpleBlobDetectorParams params, S
       new cv::Ptr<cv::SimpleBlobDetector>(cv::SimpleBlobDetector::create(ConvertCParamsToCPPParams(params)))};
   END_WRAP
 }
-void SimpleBlobDetector_Close(SimpleBlobDetector *b){CVD_FREE(b)}
+void SimpleBlobDetector_Close(SimpleBlobDetectorPtr b){CVD_FREE(b)}
 
 CvStatus SimpleBlobDetector_Detect(SimpleBlobDetector b, Mat src, VecKeyPoint *rval)
 {
@@ -291,7 +291,7 @@ CvStatus BFMatcher_CreateWithParams(int normType, bool crossCheck, BFMatcher *rv
   *rval = {new cv::Ptr<cv::BFMatcher>(cv::BFMatcher::create(normType, crossCheck))};
   END_WRAP
 }
-void BFMatcher_Close(BFMatcher *b){CVD_FREE(b)}
+void BFMatcher_Close(BFMatcherPtr b){CVD_FREE(b)}
 
 CvStatus BFMatcher_Match(BFMatcher b, Mat query, Mat train, VecDMatch *rval)
 {
@@ -316,7 +316,7 @@ CvStatus FlannBasedMatcher_Create(FlannBasedMatcher *rval)
   *rval = {new cv::Ptr<cv::FlannBasedMatcher>(cv::FlannBasedMatcher::create())};
   END_WRAP
 }
-void FlannBasedMatcher_Close(FlannBasedMatcher *f){CVD_FREE(f)}
+void FlannBasedMatcher_Close(FlannBasedMatcherPtr f){CVD_FREE(f)}
 
 CvStatus FlannBasedMatcher_KnnMatch(FlannBasedMatcher f, Mat query, Mat train, int k, VecVecDMatch *rval)
 {
@@ -341,7 +341,7 @@ CvStatus SIFT_Create(SIFT *rval)
   *rval = {new cv::Ptr<cv::SIFT>(cv::SIFT::create())};
   END_WRAP
 }
-void SIFT_Close(SIFT *f){CVD_FREE(f)}
+void SIFT_Close(SIFTPtr f){CVD_FREE(f)}
 
 CvStatus SIFT_Detect(SIFT f, Mat src, VecKeyPoint *rval)
 {

--- a/src/features2d/features2d.h
+++ b/src/features2d/features2d.h
@@ -44,19 +44,6 @@ CVD_TYPEDEF(void, FlannBasedMatcher)
 CVD_TYPEDEF(void, SIFT)
 #endif
 
-CVD_TYPEDEF_PTR(AKAZE)
-CVD_TYPEDEF_PTR(AgastFeatureDetector)
-CVD_TYPEDEF_PTR(BRISK)
-CVD_TYPEDEF_PTR(FastFeatureDetector)
-CVD_TYPEDEF_PTR(GFTTDetector)
-CVD_TYPEDEF_PTR(KAZE)
-CVD_TYPEDEF_PTR(MSER)
-CVD_TYPEDEF_PTR(ORB)
-CVD_TYPEDEF_PTR(SimpleBlobDetector)
-CVD_TYPEDEF_PTR(BFMatcher)
-CVD_TYPEDEF_PTR(FlannBasedMatcher)
-CVD_TYPEDEF_PTR(SIFT)
-
 // Wrapper for SimpleBlobDetectorParams aka SimpleBlobDetector::Params
 typedef struct SimpleBlobDetectorParams {
   unsigned char blobColor;
@@ -81,66 +68,66 @@ typedef struct SimpleBlobDetectorParams {
 } SimpleBlobDetectorParams;
 
 CvStatus AKAZE_Create(AKAZE *rval);
-void     AKAZE_Close(AKAZE *a);
+void     AKAZE_Close(AKAZEPtr a);
 CvStatus AKAZE_Detect(AKAZE a, Mat src, VecKeyPoint *rval);
 CvStatus AKAZE_DetectAndCompute(AKAZE a, Mat src, Mat mask, Mat desc, VecKeyPoint *rval);
 
 CvStatus AgastFeatureDetector_Create(AgastFeatureDetector *rval);
-void     AgastFeatureDetector_Close(AgastFeatureDetector *a);
+void     AgastFeatureDetector_Close(AgastFeatureDetectorPtr a);
 CvStatus AgastFeatureDetector_Detect(AgastFeatureDetector a, Mat src, VecKeyPoint *rval);
 
 CvStatus BRISK_Create(BRISK *rval);
-void     BRISK_Close(BRISK *b);
+void     BRISK_Close(BRISKPtr b);
 CvStatus BRISK_Detect(BRISK b, Mat src, VecKeyPoint *rval);
 CvStatus BRISK_DetectAndCompute(BRISK b, Mat src, Mat mask, Mat desc, VecKeyPoint *rval);
 
 CvStatus FastFeatureDetector_Create(FastFeatureDetector *rval);
 CvStatus FastFeatureDetector_CreateWithParams(int threshold, bool nonmaxSuppression, int type,
                                               FastFeatureDetector *rval);
-void     FastFeatureDetector_Close(FastFeatureDetector *f);
+void     FastFeatureDetector_Close(FastFeatureDetectorPtr f);
 CvStatus FastFeatureDetector_Detect(FastFeatureDetector f, Mat src, VecKeyPoint *rval);
 
 CvStatus GFTTDetector_Create(GFTTDetector *rval);
-void     GFTTDetector_Close(GFTTDetector *a);
+void     GFTTDetector_Close(GFTTDetectorPtr a);
 CvStatus GFTTDetector_Detect(GFTTDetector a, Mat src, VecKeyPoint *rval);
 
 CvStatus KAZE_Create(KAZE *rval);
-void     KAZE_Close(KAZE *a);
+void     KAZE_Close(KAZEPtr a);
 CvStatus KAZE_Detect(KAZE a, Mat src, VecKeyPoint *rval);
 CvStatus KAZE_DetectAndCompute(KAZE a, Mat src, Mat mask, Mat desc, VecKeyPoint *rval);
 
 CvStatus MSER_Create(MSER *rval);
-void     MSER_Close(MSER *a);
+void     MSER_Close(MSERPtr a);
 CvStatus MSER_Detect(MSER a, Mat src, VecKeyPoint *rval);
 
 CvStatus ORB_Create(ORB *rval);
 CvStatus ORB_CreateWithParams(int nfeatures, float scaleFactor, int nlevels, int edgeThreshold,
                               int firstLevel, int WTA_K, int scoreType, int patchSize, int fastThreshold,
                               ORB *rval);
-void     ORB_Close(ORB *o);
+void     ORB_Close(ORBPtr o);
 CvStatus ORB_Detect(ORB o, Mat src, VecKeyPoint *rval);
 CvStatus ORB_DetectAndCompute(ORB o, Mat src, Mat mask, Mat desc, VecKeyPoint *rval);
 
 CvStatus SimpleBlobDetector_Create(SimpleBlobDetector *rval);
 CvStatus SimpleBlobDetector_Create_WithParams(SimpleBlobDetectorParams params, SimpleBlobDetector *rval);
-void     SimpleBlobDetector_Close(SimpleBlobDetector *b);
+void     SimpleBlobDetector_Close(SimpleBlobDetectorPtr b);
 CvStatus SimpleBlobDetector_Detect(SimpleBlobDetector b, Mat src, VecKeyPoint *rval);
 CvStatus SimpleBlobDetectorParams_Create(SimpleBlobDetectorParams *rval);
 
 CvStatus BFMatcher_Create(BFMatcher *rval);
 CvStatus BFMatcher_CreateWithParams(int normType, bool crossCheck, BFMatcher *rval);
-void     BFMatcher_Close(BFMatcher *b);
+void     BFMatcher_Close(BFMatcherPtr b);
 CvStatus BFMatcher_Match(BFMatcher b, Mat query, Mat train, VecDMatch *rval);
 CvStatus BFMatcher_KnnMatch(BFMatcher b, Mat query, Mat train, int k, VecVecDMatch *rval);
 
 CvStatus FlannBasedMatcher_Create(FlannBasedMatcher *rval);
-void     FlannBasedMatcher_Close(FlannBasedMatcher *f);
+void     FlannBasedMatcher_Close(FlannBasedMatcherPtr f);
 CvStatus FlannBasedMatcher_KnnMatch(FlannBasedMatcher f, Mat query, Mat train, int k, VecVecDMatch *rval);
 
 CvStatus DrawKeyPoints(Mat src, VecKeyPoint kp, Mat dst, const Scalar color, int flags);
 
 CvStatus SIFT_Create(SIFT *rval);
-void     SIFT_Close(SIFT *f);
+void     SIFT_Close(SIFTPtr f);
 CvStatus SIFT_Detect(SIFT f, Mat src, VecKeyPoint *rval);
 CvStatus SIFT_DetectAndCompute(SIFT f, Mat src, Mat mask, Mat desc, VecKeyPoint *rval);
 

--- a/src/gapi/gapi.cpp
+++ b/src/gapi/gapi.cpp
@@ -15,7 +15,7 @@ CvStatus GMat_New_Empty(GMat *rval)
 //   END_WRAP
 // }
 
-void GMat_Close(GMat *mat)
+void GMat_Close(GMatPtr mat)
 {
   delete mat->ptr;
   mat->ptr = nullptr;

--- a/src/gapi/gapi.h
+++ b/src/gapi/gapi.h
@@ -21,11 +21,9 @@ CVD_TYPEDEF(cv::GMat, GMat)
 CVD_TYPEDEF(void, GMat)
 #endif
 
-CVD_TYPEDEF_PTR(GMat)
-
 CvStatus GMat_New_Empty(GMat *rval);
 // CvStatus GMat_New_FromMat(Mat mat, GMat *rval);
-void GMat_Close(GMat *mat);
+void GMat_Close(GMatPtr mat);
 
 #ifdef __cplusplus
 }

--- a/src/imgproc/imgproc.cpp
+++ b/src/imgproc/imgproc.cpp
@@ -715,7 +715,7 @@ CvStatus CLAHE_CreateWithParams(double clipLimit, Size tileGridSize, CLAHE *rval
       new cv::Ptr<cv::CLAHE>(cv::createCLAHE(clipLimit, cv::Size(tileGridSize.width, tileGridSize.height)))};
   END_WRAP
 }
-void CLAHE_Close(CLAHE *c){CVD_FREE(c)}
+void CLAHE_Close(CLAHEPtr c){CVD_FREE(c)}
 
 CvStatus CLAHE_Apply(CLAHE c, Mat src, Mat dst)
 {
@@ -764,7 +764,7 @@ CvStatus Subdiv2D_NewWithRect(Rect rect, Subdiv2D *rval)
   *rval = {new cv::Subdiv2D(cv::Rect(rect.x, rect.y, rect.width, rect.height))};
   END_WRAP
 }
-void Subdiv2D_Close(Subdiv2D *self){CVD_FREE(self)}
+void Subdiv2D_Close(Subdiv2DPtr self){CVD_FREE(self)}
 
 CvStatus Subdiv2D_EdgeDst(Subdiv2D self, int edge, Point2f *dstpt, int *rval)
 {

--- a/src/imgproc/imgproc.h
+++ b/src/imgproc/imgproc.h
@@ -25,9 +25,6 @@ CVD_TYPEDEF(void, CLAHE)
 CVD_TYPEDEF(void, Subdiv2D)
 #endif
 
-CVD_TYPEDEF_PTR(CLAHE)
-CVD_TYPEDEF_PTR(Subdiv2D)
-
 CvStatus ArcLength(VecPoint curve, bool is_closed, CVD_OUT double *rval);
 CvStatus ApproxPolyDP(VecPoint curve, double epsilon, bool closed, CVD_OUT VecPoint *rval);
 CvStatus CvtColor(Mat src, CVD_OUT Mat dst, int code);
@@ -157,7 +154,7 @@ CvStatus ClipLine(Rect imgRect, Point pt1, Point pt2, bool *rval);
 
 CvStatus CLAHE_Create(CLAHE *rval);
 CvStatus CLAHE_CreateWithParams(double clipLimit, Size tileGridSize, CLAHE *rval);
-void     CLAHE_Close(CLAHE *c);
+void     CLAHE_Close(CLAHEPtr c);
 CvStatus CLAHE_Apply(CLAHE c, Mat src, Mat dst);
 CvStatus CLAHE_CollectGarbage(CLAHE c);
 CvStatus CLAHE_GetClipLimit(CLAHE c, double *rval);
@@ -167,7 +164,7 @@ CvStatus CLAHE_SetTilesGridSize(CLAHE c, Size size);
 
 CvStatus Subdiv2D_NewEmpty(Subdiv2D *rval);
 CvStatus Subdiv2D_NewWithRect(Rect rect, Subdiv2D *rval);
-void     Subdiv2D_Close(Subdiv2D *self);
+void     Subdiv2D_Close(Subdiv2DPtr self);
 CvStatus Subdiv2D_EdgeDst(Subdiv2D self, int edge, Point2f *dstpt, int *rval);
 CvStatus Subdiv2D_EdgeOrg(Subdiv2D self, int edge, Point2f *orgpt, int *rval);
 CvStatus Subdiv2D_FindNearest(Subdiv2D self, Point2f pt, Point2f *nearestPt, int *rval);

--- a/src/objdetect/objdetect.cpp
+++ b/src/objdetect/objdetect.cpp
@@ -23,7 +23,7 @@ CvStatus CascadeClassifier_NewFromFile(char *filename, CascadeClassifier *rval)
   *rval = {new cv::CascadeClassifier(filename)};
   END_WRAP
 }
-void CascadeClassifier_Close(CascadeClassifier *self){CVD_FREE(self)}
+void CascadeClassifier_Close(CascadeClassifierPtr self){CVD_FREE(self)}
 
 CvStatus CascadeClassifier_Load(CascadeClassifier self, const char *name, int *rval)
 {
@@ -123,7 +123,7 @@ CvStatus HOGDescriptor_NewFromFile(char *filename, HOGDescriptor *rval)
   *rval = {new cv::HOGDescriptor(filename)};
   END_WRAP
 }
-void HOGDescriptor_Close(HOGDescriptor *self){CVD_FREE(self)}
+void HOGDescriptor_Close(HOGDescriptorPtr self){CVD_FREE(self)}
 
 CvStatus HOGDescriptor_Load(HOGDescriptor self, char *name, bool *rval)
 {
@@ -331,7 +331,7 @@ CvStatus QRCodeDetector_detectAndDecodeCurved(QRCodeDetector self, Mat img, VecP
   *straight_qrcode = {_straight_qrcode};
   END_WRAP
 }
-void QRCodeDetector_Close(QRCodeDetector *self){CVD_FREE(self)}
+void QRCodeDetector_Close(QRCodeDetectorPtr self){CVD_FREE(self)}
 
 CvStatus QRCodeDetector_DetectMulti(QRCodeDetector self, Mat input, VecPoint *points, bool *rval)
 {

--- a/src/objdetect/objdetect.h
+++ b/src/objdetect/objdetect.h
@@ -28,14 +28,10 @@ CVD_TYPEDEF(void, HOGDescriptor)
 CVD_TYPEDEF(void, QRCodeDetector)
 #endif
 
-CVD_TYPEDEF_PTR(CascadeClassifier)
-CVD_TYPEDEF_PTR(HOGDescriptor)
-CVD_TYPEDEF_PTR(QRCodeDetector)
-
 // CascadeClassifier
 CvStatus CascadeClassifier_New(CascadeClassifier *rval);
 CvStatus CascadeClassifier_NewFromFile(char *filename, CascadeClassifier *rval);
-void     CascadeClassifier_Close(CascadeClassifier *self);
+void     CascadeClassifier_Close(CascadeClassifierPtr self);
 CvStatus CascadeClassifier_Load(CascadeClassifier self, const char *name, int *rval);
 CvStatus CascadeClassifier_DetectMultiScale(CascadeClassifier self, Mat img, VecRect *rval);
 CvStatus CascadeClassifier_DetectMultiScaleWithParams(CascadeClassifier self, Mat img, VecRect *objects,
@@ -63,7 +59,7 @@ CvStatus CascadeClassifier_isOldFormatCascade(CascadeClassifier self, bool *rval
 
 CvStatus HOGDescriptor_New(HOGDescriptor *rval);
 CvStatus HOGDescriptor_NewFromFile(char *filename, HOGDescriptor *rval);
-void     HOGDescriptor_Close(HOGDescriptor *self);
+void     HOGDescriptor_Close(HOGDescriptorPtr self);
 CvStatus HOGDescriptor_Load(HOGDescriptor self, char *name, bool *rval);
 CvStatus HOGDescriptor_Detect(HOGDescriptor self, Mat img, VecPoint *foundLocations, VecDouble *weights,
                               double hitThresh, Size winStride, Size padding, VecPoint *searchLocations);
@@ -97,7 +93,7 @@ CvStatus GroupRectangles(VecRect rects, int groupThreshold, double eps);
 
 // QRCodeDetector
 CvStatus QRCodeDetector_New(QRCodeDetector *rval);
-void     QRCodeDetector_Close(QRCodeDetector *self);
+void     QRCodeDetector_Close(QRCodeDetectorPtr self);
 CvStatus QRCodeDetector_DetectAndDecode(QRCodeDetector self, Mat input, VecPoint *points,
                                         Mat *straight_qrcode, char **rval);
 CvStatus QRCodeDetector_Detect(QRCodeDetector self, Mat input, VecPoint *points, bool *rval);

--- a/src/photo/photo.cpp
+++ b/src/photo/photo.cpp
@@ -98,7 +98,7 @@ CvStatus MergeMertens_Process(MergeMertens b, VecMat src, Mat dst)
   BEGIN_WRAP(*b.ptr)->process(*src.ptr, *dst.ptr);
   END_WRAP
 }
-void MergeMertens_Close(MergeMertens *b){CVD_FREE(b)}
+void MergeMertens_Close(MergeMertensPtr b){CVD_FREE(b)}
 
 CvStatus AlignMTB_Create(AlignMTB *rval)
 {
@@ -120,7 +120,7 @@ CvStatus AlignMTB_Process(AlignMTB b, VecMat src, VecMat *dst)
   *dst = {new std::vector<cv::Mat>(vec)};
   END_WRAP
 }
-void AlignMTB_Close(AlignMTB *b){CVD_FREE(b)}
+void AlignMTB_Close(AlignMTBPtr b){CVD_FREE(b)}
 
 CvStatus DetailEnhance(Mat src, Mat dst, float sigma_s, float sigma_r)
 {

--- a/src/photo/photo.h
+++ b/src/photo/photo.h
@@ -27,9 +27,6 @@ CVD_TYPEDEF(void, MergeMertens)
 CVD_TYPEDEF(void, AlignMTB)
 #endif
 
-CVD_TYPEDEF_PTR(MergeMertens)
-CVD_TYPEDEF_PTR(AlignMTB)
-
 CvStatus ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul);
 
 CvStatus SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags);
@@ -54,12 +51,12 @@ CvStatus MergeMertens_Create(MergeMertens *rval);
 CvStatus MergeMertens_CreateWithParams(float contrast_weight, float saturation_weight, float exposure_weight,
                                        MergeMertens *rval);
 CvStatus MergeMertens_Process(MergeMertens b, VecMat src, Mat dst);
-void     MergeMertens_Close(MergeMertens *b);
+void     MergeMertens_Close(MergeMertensPtr b);
 
 CvStatus AlignMTB_Create(AlignMTB *rval);
 CvStatus AlignMTB_CreateWithParams(int max_bits, int exclude_range, bool cut, AlignMTB *rval);
 CvStatus AlignMTB_Process(AlignMTB b, VecMat src, VecMat *dst);
-void     AlignMTB_Close(AlignMTB *b);
+void     AlignMTB_Close(AlignMTBPtr b);
 
 CvStatus DetailEnhance(Mat src, Mat dst, float sigma_s, float sigma_r);
 CvStatus EdgePreservingFilter(Mat src, Mat dst, int filter, float sigma_s, float sigma_r);

--- a/src/stitching/stitching.cpp
+++ b/src/stitching/stitching.cpp
@@ -13,7 +13,7 @@ CvStatus Stitcher_Create(int mode, PtrStitcher *rval)
   END_WRAP
 }
 
-void Stitcher_Close(PtrStitcher *stitcher){CVD_FREE(stitcher)}
+void Stitcher_Close(PtrStitcherPtr stitcher){CVD_FREE(stitcher)}
 
 CvStatus Stitcher_Get(PtrStitcher self, Stitcher *rval)
 {

--- a/src/stitching/stitching.h
+++ b/src/stitching/stitching.h
@@ -30,11 +30,8 @@ CVD_TYPEDEF(void *, PtrStitcher)
 CVD_TYPEDEF(void, Stitcher)
 #endif
 
-CVD_TYPEDEF_PTR(PtrStitcher)
-CVD_TYPEDEF_PTR(Stitcher)
-
 CvStatus Stitcher_Create(int mode, PtrStitcher *rval);
-void     Stitcher_Close(PtrStitcher *stitcher);
+void     Stitcher_Close(PtrStitcherPtr stitcher);
 CvStatus Stitcher_Get(PtrStitcher self, Stitcher *rval);
 
 #pragma region getter/setter

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -23,7 +23,7 @@ CvStatus BackgroundSubtractorMOG2_CreateWithParams(int history, double varThresh
       cv::createBackgroundSubtractorMOG2(history, varThreshold, detectShadows))};
   END_WRAP
 }
-void BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2 *self){CVD_FREE(self)}
+void BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2Ptr self){CVD_FREE(self)}
 
 CvStatus BackgroundSubtractorMOG2_Apply(BackgroundSubtractorMOG2 self, Mat src, Mat dst)
 {
@@ -45,7 +45,7 @@ CvStatus BackgroundSubtractorKNN_CreateWithParams(int history, double dist2Thres
       cv::createBackgroundSubtractorKNN(history, dist2Threshold, detectShadows))};
   END_WRAP
 }
-void BackgroundSubtractorKNN_Close(BackgroundSubtractorKNN *self){CVD_FREE(self)}
+void BackgroundSubtractorKNN_Close(BackgroundSubtractorKNNPtr self){CVD_FREE(self)}
 
 CvStatus BackgroundSubtractorKNN_Apply(BackgroundSubtractorKNN self, Mat src, Mat dst)
 {
@@ -115,7 +115,7 @@ CvStatus TrackerMIL_Create(TrackerMIL *rval)
   *rval = {new cv::Ptr<cv::TrackerMIL>(cv::TrackerMIL::create())};
   END_WRAP
 }
-void TrackerMIL_Close(TrackerMIL *self){CVD_FREE(self)}
+void TrackerMIL_Close(TrackerMILPtr self){CVD_FREE(self)}
 
 CvStatus KalmanFilter_New(int dynamParams, int measureParams, int controlParams, int type, KalmanFilter *rval)
 {
@@ -123,7 +123,7 @@ CvStatus KalmanFilter_New(int dynamParams, int measureParams, int controlParams,
   *rval = {new cv::KalmanFilter(dynamParams, measureParams, controlParams, type)};
   END_WRAP
 }
-void KalmanFilter_Close(KalmanFilter *self){CVD_FREE(self)}
+void KalmanFilter_Close(KalmanFilterPtr self){CVD_FREE(self)}
 
 CvStatus KalmanFilter_Init(KalmanFilter self, int dynamParams, int measureParams)
 {

--- a/src/video/video.h
+++ b/src/video/video.h
@@ -33,23 +33,16 @@ CVD_TYPEDEF(void, TrackerGOTURN)
 CVD_TYPEDEF(void, KalmanFilter)
 #endif
 
-CVD_TYPEDEF_PTR(BackgroundSubtractorMOG2)
-CVD_TYPEDEF_PTR(BackgroundSubtractorKNN)
-CVD_TYPEDEF_PTR(Tracker)
-CVD_TYPEDEF_PTR(TrackerMIL)
-CVD_TYPEDEF_PTR(TrackerGOTURN)
-CVD_TYPEDEF_PTR(KalmanFilter)
-
 CvStatus BackgroundSubtractorMOG2_Create(BackgroundSubtractorMOG2 *rval);
 CvStatus BackgroundSubtractorMOG2_CreateWithParams(int history, double varThreshold, bool detectShadows,
                                                    BackgroundSubtractorMOG2 *rval);
-void     BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2 *self);
+void     BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2Ptr self);
 CvStatus BackgroundSubtractorMOG2_Apply(BackgroundSubtractorMOG2 self, Mat src, Mat dst);
 
 CvStatus BackgroundSubtractorKNN_Create(BackgroundSubtractorKNN *rval);
 CvStatus BackgroundSubtractorKNN_CreateWithParams(int history, double dist2Threshold, bool detectShadows,
                                                   BackgroundSubtractorKNN *rval);
-void     BackgroundSubtractorKNN_Close(BackgroundSubtractorKNN *self);
+void     BackgroundSubtractorKNN_Close(BackgroundSubtractorKNNPtr self);
 CvStatus BackgroundSubtractorKNN_Apply(BackgroundSubtractorKNN self, Mat src, Mat dst);
 
 CvStatus CalcOpticalFlowPyrLK(Mat prevImg, Mat nextImg, VecPoint2f prevPts, VecPoint2f nextPts,
@@ -66,11 +59,11 @@ CvStatus FindTransformECC(Mat templateImage, Mat inputImage, Mat warpMatrix, int
 CvStatus TrackerMIL_Init(TrackerMIL self, Mat image, Rect bbox);
 CvStatus TrackerMIL_Update(TrackerMIL self, Mat image, Rect *boundingBox, bool *rval);
 CvStatus TrackerMIL_Create(TrackerMIL *rval);
-void     TrackerMIL_Close(TrackerMIL *self);
+void     TrackerMIL_Close(TrackerMILPtr self);
 
 CvStatus KalmanFilter_New(int dynamParams, int measureParams, int controlParams, int type,
                           KalmanFilter *rval);
-void     KalmanFilter_Close(KalmanFilter *self);
+void     KalmanFilter_Close(KalmanFilterPtr self);
 
 CvStatus KalmanFilter_Init(KalmanFilter self, int dynamParams, int measureParams);
 CvStatus KalmanFilter_InitWithParams(KalmanFilter self, int dynamParams, int measureParams, int controlParams,

--- a/src/video/videoio.cpp
+++ b/src/video/videoio.cpp
@@ -27,7 +27,7 @@ CvStatus VideoCapture_NewFromIndex(int index, int apiPreference, VideoCapture *r
   *rval = {new cv::VideoCapture(index, apiPreference)};
   END_WRAP
 }
-void VideoCapture_Close(VideoCapture *self){CVD_FREE(self)}
+void VideoCapture_Close(VideoCapturePtr self){CVD_FREE(self)}
 
 CvStatus VideoCapture_Open(VideoCapture self, const char *uri, bool *rval)
 {
@@ -97,7 +97,7 @@ CvStatus VideoWriter_New(VideoWriter *rval)
   *rval = {new cv::VideoWriter()};
   END_WRAP
 }
-void VideoWriter_Close(VideoWriter *self){CVD_FREE(self)}
+void VideoWriter_Close(VideoWriterPtr self){CVD_FREE(self)}
 
 CvStatus VideoWriter_Open(VideoWriter self, const char *name, const char *codec, double fps, int width,
                           int height, bool isColor)

--- a/src/video/videoio.h
+++ b/src/video/videoio.h
@@ -24,14 +24,11 @@ CVD_TYPEDEF(void, VideoCapture)
 CVD_TYPEDEF(void, VideoWriter)
 #endif
 
-CVD_TYPEDEF_PTR(VideoCapture)
-CVD_TYPEDEF_PTR(VideoWriter)
-
 // VideoCapture
 CvStatus VideoCapture_New(VideoCapture *rval);
 CvStatus VideoCapture_NewFromFile(const char *filename, int apiPreference, VideoCapture *rval);
 CvStatus VideoCapture_NewFromIndex(int index, int apiPreference, VideoCapture *rval);
-void     VideoCapture_Close(VideoCapture *self);
+void     VideoCapture_Close(VideoCapturePtr self);
 CvStatus VideoCapture_Open(VideoCapture self, const char *uri, bool *rval);
 CvStatus VideoCapture_OpenWithAPI(VideoCapture self, const char *uri, int apiPreference, bool *rval);
 CvStatus VideoCapture_OpenDevice(VideoCapture self, int device, bool *rval);
@@ -45,7 +42,7 @@ CvStatus VideoCapture_Grab(VideoCapture self, int skip);
 
 // VideoWriter
 CvStatus VideoWriter_New(VideoWriter *rval);
-void     VideoWriter_Close(VideoWriter *self);
+void     VideoWriter_Close(VideoWriterPtr self);
 CvStatus VideoWriter_Open(VideoWriter self, const char *name, const char *codec, double fps, int width,
                           int height, bool isColor);
 CvStatus VideoWriter_IsOpened(VideoWriter self, int *rval);


### PR DESCRIPTION
Remove all CVD_TYPEDEF_PTR.

this macro is used to define wrappers pointers to use in dart conveniently, ffigen will not generate typedefs not referred so this macro also defined a struct to refer pointers, now all wrapper pointers are referred in `*_Close` so the macro not needed any more, clean C codes.