### PR TITLE
Android Plugin custom arch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OpenCV Bindings for Dart Language. Support both asynchronous and synchronous!
 > 1. If you want to setup manually, please set `OPENCV_DART_DISABLE_AUTO_BUILD` environment variable,
 > e.g., `export OPENCV_DART_DISABLE_AUTO_BUILD=1`(for Unix-like)
 > or `$env:OPENCV_DART_DISABLE_AUTO_BUILD=1`(for Windows)
-
+>
 > For `v1.0.4` and below, make sure run the following setup commands before running your app:
 >
 > 1. `flutter pub add opencv_dart` or `dart pub add opencv_dart`
@@ -159,17 +159,9 @@ void main() {
 
 #### Flutter
 
-> Android only
-> 
-> if you want build Android apk with custom arch , you can set `OPENCV_DART_ANDROID_SUPPORT_ARCHS` environment variable before **flutter build** 
->
-> e.g., `export OPENCV_DART_ANDROID_SUPPORT_ARCHS=arm64-v8a,armeabi-v7a`(for Unix-like)
-> 
-> or `$env:OPENCV_DART_DISABLE_AUTO_BUILD=arm64-v8a,armeabi-v7a`(for Windows)
-
 see [example](https://github.com/rainyl/opencv_dart/tree/main/example)
 
-~~More examples are on the way...~~see [opencv_dart.examples](https://github.com/rainyl/opencv_dart.examples) and share yours
+~~More examples are on the way...~~ see [awesome-opencv_dart](https://github.com/rainyl/awesome-opencv_dart) and share yours
 
 ### TODO
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ void main() {
 > 
 > if you want build Android apk with custom arch , you can set `OPENCV_DART_ANDROID_SUPPORT_ARCHS` environment variable before **flutter build** 
 >
-> e.g., `export OPENCV_DART_ANDROID_SUPPORT_ARCHS=x86_64,arm64-v8a`(for Unix-like)
+> e.g., `export OPENCV_DART_ANDROID_SUPPORT_ARCHS=arm64-v8a,armeabi-v7a`(for Unix-like)
 > 
-> or `$env:OPENCV_DART_DISABLE_AUTO_BUILD=x86_64,arm64-v8a`(for Windows)
+> or `$env:OPENCV_DART_DISABLE_AUTO_BUILD=arm64-v8a,armeabi-v7a`(for Windows)
 
 see [example](https://github.com/rainyl/opencv_dart/tree/main/example)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OpenCV Bindings for Dart Language. Support both asynchronous and synchronous!
 > 1. If you want to setup manually, please set `OPENCV_DART_DISABLE_AUTO_BUILD` environment variable,
 > e.g., `export OPENCV_DART_DISABLE_AUTO_BUILD=1`(for Unix-like)
 > or `$env:OPENCV_DART_DISABLE_AUTO_BUILD=1`(for Windows)
->
+
 > For `v1.0.4` and below, make sure run the following setup commands before running your app:
 >
 > 1. `flutter pub add opencv_dart` or `dart pub add opencv_dart`
@@ -158,6 +158,14 @@ void main() {
 ```
 
 #### Flutter
+
+> Android only
+> 
+> if you want build Android apk with custom arch , you can set `OPENCV_DART_ANDROID_SUPPORT_ARCHS` environment variable before **flutter build** 
+>
+> e.g., `export OPENCV_DART_ANDROID_SUPPORT_ARCHS=x86_64,arm64-v8a`(for Unix-like)
+> 
+> or `$env:OPENCV_DART_DISABLE_AUTO_BUILD=x86_64,arm64-v8a`(for Windows)
 
 see [example](https://github.com/rainyl/opencv_dart/tree/main/example)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,21 +72,24 @@ def CACHE_DIR = SOURCE_DIR.parentFile
 def CVD_VERSION = new File("${project.buildscript.sourceFile.parentFile.parentFile}/binary.version").text
 def CVD_LIB_URL_BASE = "https://github.com/rainyl/opencv_dart/releases/download"
 def ARCHS = ['x86_64', 'arm64-v8a', 'armeabi-v7a']
-def OPENCV_DART_ANDROID_SUPPORT_ARCHS=System.env.OPENCV_DART_ANDROID_SUPPORT_ARCHS ?: null
-if(OPENCV_DART_ANDROID_SUPPORT_ARCHS != null){
-    println "OPENCV_DART_ANDROID_SUPPORT_ARCHS is defined : $OPENCV_DART_ANDROID_SUPPORT_ARCHS"
-    def supportedArchs = OPENCV_DART_ANDROID_SUPPORT_ARCHS.split(",")
-    def acceptedArchs = []
-    supportedArchs.each { supportArch ->
-        if(ARCHS.contains(supportArch)){
-            println "[opencv_dart] Support arch: ${supportArch}"
-            acceptedArchs.add(supportArch)
-        }else{
-            println "[opencv_dart] Unsupport arch: ${supportArch}"
+
+def OPENCV_DART_ANDROID_ENABLED_ABI = System.env.OPENCV_DART_ANDROID_ENABLED_ABI ?: null
+if(OPENCV_DART_ANDROID_ENABLED_ABI != null){
+    println "[opencv_dart] detected OPENCV_DART_ANDROID_ENABLED_ABI : $OPENCV_DART_ANDROID_ENABLED_ABI"
+    def enabledABI = OPENCV_DART_ANDROID_ENABLED_ABI.split(",")
+    def acceptedABI = []
+    enabledABI.each { abi ->
+        if(ARCHS.contains(abi)){
+            println "[opencv_dart] add abi: ${abi}"
+            acceptedABI.add(abi)
+        } else {
+            println "[opencv_dart] invalid abi: ${abi}"
         }
     }
-    println "[opencv_dart] OPENCV_DART for Android support arch : $acceptedArchs"
-    ARCHS = acceptedArchs
+    println "[opencv_dart] accepted abi: $acceptedABI"
+    if (acceptedABI){
+        ARCHS = acceptedABI
+    }
 }
 
 task downloadLibs(type: Download) {
@@ -111,12 +114,7 @@ ARCHS.each { arch ->
     }
 }
 
-task cleanupExtractLibs(type: Delete) {
-    println "[opencv_dart] Cleaning up opencv_dart libraries..."
-    delete "${SOURCE_DIR}/src/main/jniLibs"
-}
-
-task extractLibs(dependsOn: [downloadLibs,cleanupExtractLibs]) {
+task extractLibs(dependsOn: [downloadLibs]) {
     println "[opencv_dart] Extracting libraries..."
     ARCHS.each { arch ->
         finalizedBy "opencv_dart_extract_libs_${arch}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ def ARCHS = ['x86_64', 'arm64-v8a', 'armeabi-v7a']
 
 def OPENCV_DART_ANDROID_ENABLED_ABI = System.env.OPENCV_DART_ANDROID_ENABLED_ABI ?: null
 if(OPENCV_DART_ANDROID_ENABLED_ABI != null){
-    println "[opencv_dart] detected OPENCV_DART_ANDROID_ENABLED_ABI : $OPENCV_DART_ANDROID_ENABLED_ABI"
+    println "[opencv_dart] detected OPENCV_DART_ANDROID_ENABLED_ABI: $OPENCV_DART_ANDROID_ENABLED_ABI"
     def enabledABI = OPENCV_DART_ANDROID_ENABLED_ABI.split(",")
     def acceptedABI = []
     enabledABI.each { abi ->
@@ -83,12 +83,15 @@ if(OPENCV_DART_ANDROID_ENABLED_ABI != null){
             println "[opencv_dart] add abi: ${abi}"
             acceptedABI.add(abi)
         } else {
-            println "[opencv_dart] invalid abi: ${abi}"
+            println "[opencv_dart] invalid abi: ${abi}, ignored"
         }
     }
     println "[opencv_dart] accepted abi: $acceptedABI"
     if (acceptedABI){
         ARCHS = acceptedABI
+    } else {
+        println "[opencv_dart] invalid OPENCV_DART_ANDROID_ENABLED_ABI: $OPENCV_DART_ANDROID_ENABLED_ABI"
+        println "[opencv_dart] will enable all supported ABI: $ARCHS"
     }
 }
 
@@ -114,7 +117,7 @@ ARCHS.each { arch ->
     }
 }
 
-task extractLibs(dependsOn: [downloadLibs]) {
+task extractLibs(dependsOn: downloadLibs) {
     println "[opencv_dart] Extracting libraries..."
     ARCHS.each { arch ->
         finalizedBy "opencv_dart_extract_libs_${arch}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,13 +79,13 @@ if(OPENCV_DART_ANDROID_SUPPORT_ARCHS != null){
     def acceptedArchs = []
     supportedArchs.each { supportArch ->
         if(ARCHS.contains(supportArch)){
-            println "Support arch: ${supportArch}"
+            println "[opencv_dart] Support arch: ${supportArch}"
             acceptedArchs.add(supportArch)
         }else{
-            println "Unsupport arch: ${supportArch}"
+            println "[opencv_dart] Unsupport arch: ${supportArch}"
         }
     }
-    println "OPENCV_DART for Android support arch : $acceptedArchs"
+    println "[opencv_dart] OPENCV_DART for Android support arch : $acceptedArchs"
     ARCHS = acceptedArchs
 }
 
@@ -112,7 +112,7 @@ ARCHS.each { arch ->
 }
 
 task cleanupExtractLibs(type: Delete) {
-    println "Cleaning up opencv_dart libraries..."
+    println "[opencv_dart] Cleaning up opencv_dart libraries..."
     delete "${SOURCE_DIR}/src/main/jniLibs"
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,10 +68,12 @@ android {
 }
 
 def SOURCE_DIR = project.buildscript.sourceFile.parentFile
-def CACHE_DIR = SOURCE_DIR.parentFile
-def CVD_VERSION = new File("${project.buildscript.sourceFile.parentFile.parentFile}/binary.version").text
+def ROOT_DIR = SOURCE_DIR.parentFile
+def CACHE_DIR = new File("${ROOT_DIR}/.dart_tool/.cache")
+def CVD_VERSION = new File("${ROOT_DIR}/binary.version").text
 def CVD_LIB_URL_BASE = "https://github.com/rainyl/opencv_dart/releases/download"
-def ARCHS = ['x86_64', 'arm64-v8a', 'armeabi-v7a']
+def ABI_ALL = ['x86_64', 'arm64-v8a', 'armeabi-v7a']
+def ABI_ACCEPTED = ['x86_64', 'arm64-v8a', 'armeabi-v7a']
 
 def OPENCV_DART_ANDROID_ENABLED_ABI = System.env.OPENCV_DART_ANDROID_ENABLED_ABI ?: null
 if(OPENCV_DART_ANDROID_ENABLED_ABI != null){
@@ -79,7 +81,7 @@ if(OPENCV_DART_ANDROID_ENABLED_ABI != null){
     def enabledABI = OPENCV_DART_ANDROID_ENABLED_ABI.split(",")
     def acceptedABI = []
     enabledABI.each { abi ->
-        if(ARCHS.contains(abi)){
+        if(ABI_ALL.contains(abi)){
             println "[opencv_dart] add abi: ${abi}"
             acceptedABI.add(abi)
         } else {
@@ -88,16 +90,35 @@ if(OPENCV_DART_ANDROID_ENABLED_ABI != null){
     }
     println "[opencv_dart] accepted abi: $acceptedABI"
     if (acceptedABI){
-        ARCHS = acceptedABI
+        ABI_ACCEPTED = acceptedABI
     } else {
         println "[opencv_dart] invalid OPENCV_DART_ANDROID_ENABLED_ABI: $OPENCV_DART_ANDROID_ENABLED_ABI"
-        println "[opencv_dart] will enable all supported ABI: $ARCHS"
+        println "[opencv_dart] will enable all supported ABI: $ABI_ACCEPTED"
+    }
+}
+
+ABI_ALL.each { arch ->
+    def extractTaskName = "opencv_dart_extract_libs_${arch}"
+    def targetDir = new File("${SOURCE_DIR}/src/main/jniLibs/${arch}")
+    if (targetDir.exists() && !ABI_ACCEPTED.contains(arch)) {
+        println "[opencv_dart] Deleting libraries for ${arch}..."
+        delete targetDir
+    }
+    task(extractTaskName, type: Copy) {
+        onlyIf {
+          ABI_ACCEPTED.contains(arch) && !file("${targetDir}/libopencv_dart.so").exists()
+        }
+        doFirst {
+            println "[opencv_dart] Extracting libraries for ${arch}..."
+        }
+        from tarTree(resources.gzip("${CACHE_DIR}/libopencv_dart-android-${arch}.tar.gz"))
+        into targetDir
     }
 }
 
 task downloadLibs(type: Download) {
     println "[opencv_dart] Downloading libraries..."
-    def SRC_URLS = ARCHS.collect { ARCH ->
+    def SRC_URLS = ABI_ACCEPTED.collect { ARCH ->
         "${CVD_LIB_URL_BASE}/v${CVD_VERSION}/libopencv_dart-android-${ARCH}.tar.gz"
     }
     src(SRC_URLS)
@@ -105,23 +126,12 @@ task downloadLibs(type: Download) {
     overwrite false
 }
 
-ARCHS.each { arch ->
-    def extractTaskName = "opencv_dart_extract_libs_${arch}"
-    task(extractTaskName, type: Copy) {
-        def targetDir = new File("${SOURCE_DIR}/src/main/jniLibs/${arch}")
-        onlyIf {
-            !file("${targetDir}/libopencv_dart.so").exists()
-        }
-        from tarTree(resources.gzip("${CACHE_DIR}/libopencv_dart-android-${arch}.tar.gz"))
-        into targetDir
-    }
-}
-
 task extractLibs(dependsOn: downloadLibs) {
     println "[opencv_dart] Extracting libraries..."
-    ARCHS.each { arch ->
-        finalizedBy "opencv_dart_extract_libs_${arch}"
+    ABI_ALL.each { arch ->
+        dependsOn "opencv_dart_extract_libs_${arch}"
     }
+
     doLast {
       println "[opencv_dart] Extract finished."
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,6 +72,22 @@ def CACHE_DIR = SOURCE_DIR.parentFile
 def CVD_VERSION = new File("${project.buildscript.sourceFile.parentFile.parentFile}/binary.version").text
 def CVD_LIB_URL_BASE = "https://github.com/rainyl/opencv_dart/releases/download"
 def ARCHS = ['x86_64', 'arm64-v8a', 'armeabi-v7a']
+def OPENCV_DART_ANDROID_SUPPORT_ARCHS=System.env.OPENCV_DART_ANDROID_SUPPORT_ARCHS ?: null
+if(OPENCV_DART_ANDROID_SUPPORT_ARCHS != null){
+    println "OPENCV_DART_ANDROID_SUPPORT_ARCHS is defined : $OPENCV_DART_ANDROID_SUPPORT_ARCHS"
+    def supportedArchs = OPENCV_DART_ANDROID_SUPPORT_ARCHS.split(",")
+    def acceptedArchs = []
+    supportedArchs.each { supportArch ->
+        if(ARCHS.contains(supportArch)){
+            println "Support arch: ${supportArch}"
+            acceptedArchs.add(supportArch)
+        }else{
+            println "Unsupport arch: ${supportArch}"
+        }
+    }
+    println "OPENCV_DART for Android support arch : $acceptedArchs"
+    ARCHS = acceptedArchs
+}
 
 task downloadLibs(type: Download) {
     println "[opencv_dart] Downloading libraries..."
@@ -95,7 +111,12 @@ ARCHS.each { arch ->
     }
 }
 
-task extractLibs(dependsOn: downloadLibs) {
+task cleanupExtractLibs(type: Delete) {
+    println "Cleaning up opencv_dart libraries..."
+    delete "${SOURCE_DIR}/src/main/jniLibs"
+}
+
+task extractLibs(dependsOn: [downloadLibs,cleanupExtractLibs]) {
     println "[opencv_dart] Extracting libraries..."
     ARCHS.each { arch ->
         finalizedBy "opencv_dart_extract_libs_${arch}"


### PR DESCRIPTION
I'm use `opencv_dart` on my project , but release apk files that are getting to big,I try to optimize file sizes,so I found the apk with some binary file is no need.

so I find a way to exclude so file on useless arch.

this PR just for Android Plugin work , just work well on me , I did't compile and test complete opencv_dart , can't change code with C/C++/MAKEFILE chain tool thing because I not work on these and no executable environment.

you may need complete build/testing pipeline to verify merge code.

I added `OPENCV_DART_ANDROID_SUPPORT_ARCHS` flag on file android/build.gradle.

can let user set environment before build apk (Android only) , android gradle prebuild task will only copy support arch **.so** file with only need.

here is use case:

flutter build release without `OPENCV_DART_ANDROID_SUPPORT_ARCHS` define
```
unset OPENCV_DART_ANDROID_SUPPORT_ARCHS
flutter build apk --release
✓ Built build/app/outputs/flutter-apk/app-release.apk (200.1MB)
```

flutter build release with `OPENCV_DART_ANDROID_SUPPORT_ARCHS`  define `arm64-v8a,armeabi-v7a`
```
export OPENCV_DART_ANDROID_SUPPORT_ARCHS=arm64-v8a,armeabi-v7a
flutter build apk --release 
✓ Built build/app/outputs/flutter-apk/app-release.apk (141.8MB)
```

flutter build release with `OPENCV_DART_ANDROID_SUPPORT_ARCHS`  define `arm64-v8a,armeabi-v7a` 

and specified  `--target-platform=android-arm,android-arm64` (not include **libflutter.so** on x86/x86_64)
```
export OPENCV_DART_ANDROID_SUPPORT_ARCHS=arm64-v8a,armeabi-v7a
flutter build apk --release --target-platform=android-arm,android-arm64
✓ Built build/app/outputs/flutter-apk/app-release.apk (123.9MB)
```


`OPENCV_DART_ANDROID_SUPPORT_ARCHS` FLAG an only receive 'x86_64', 'arm64-v8a', 'armeabi-v7a' for now

subject to `ARCHS` on android/build.gradle
```
def ARCHS = ['x86_64', 'arm64-v8a', 'armeabi-v7a']
```
which mean if you type in an arch that doesn't exist / support , will skip it 
```
[opencv_dart] OPENCV_DART_ANDROID_SUPPORT_ARCHS is defined : x86_64,arm64-v8a,x86
[opencv_dart] Support arch: x86_64
[opencv_dart] Support arch: arm64-v8a
[opencv_dart] Unsupport arch: x86
[opencv_dart] OPENCV_DART for Android support arch : [x86_64, arm64-v8a]

```

issues : 

in addition, I found that the ios makefile script only supports os64 arch, no arm64 and os64, which means opencv_dart can’t run on ios emulator ? I did’t test yet.


remind : 

I saw your license not add name of copyright owner 