### PR TITLE
remove macos_arm_size_report.json

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -478,11 +478,11 @@ jobs:
           }
           EOL
 
-      # - name: Upload size report
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: macos-arm-size-report
-      #     path: macos_arm_size_report.json
+      - name: Upload size report
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm-size-report
+          path: macos_arm_size_report.json
 
   combine-reports:
     name: Generate Combined Size Reports

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -491,8 +491,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       # - name: Set up Python
       #   uses: actions/setup-python@v5

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -491,6 +491,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Checkout the fork/head-repository and push changes to the fork.
+          # If you skip this, the base repository will be checked out and changes
+          # will be committed to the base repository!
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+          # Checkout the branch made in the fork. Will automatically push changes
+          # back to this branch.
+          ref: ${{ github.head_ref }}
 
       # - name: Set up Python
       #   uses: actions/setup-python@v5

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -488,6 +488,10 @@ jobs:
     name: Generate Combined Size Reports
     needs: [windows, android, ios, linux, macos, macos-arm]
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -478,11 +478,11 @@ jobs:
           }
           EOL
 
-      - name: Upload size report
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-arm-size-report
-          path: macos_arm_size_report.json
+      # - name: Upload size report
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: macos-arm-size-report
+      #     path: macos_arm_size_report.json
 
   combine-reports:
     name: Generate Combined Size Reports

--- a/scripts/generate_combined_report.py
+++ b/scripts/generate_combined_report.py
@@ -51,7 +51,7 @@ def consolidate_data(reports: list) -> Dict[str, Any]:
                 data = json.load(f)
                 for package, sizes in data.items():
                     if (
-                        package == "base_size" or package == "platform"
+                        package == "base_size" or package == "platform" or platform.lower() == "macos_arm"
                     ):  # Skip platform mapping
                         continue
                     if package not in combined:


### PR DESCRIPTION
i just removed the upload json and the python script will auto adjust to the svg creation, i only commented it in case we needed to enable it for any reason

fixing: https://github.com/rainyl/opencv_dart/issues/282#issuecomment-2453996329