### PR TITLE
make the version of `dartcv4` fixed (without `^`) in opencv_core and …

### DIFF
--- a/packages/opencv_core/CHANGELOG.md
+++ b/packages/opencv_core/CHANGELOG.md
@@ -7,6 +7,8 @@
 * use native implementation of 8U/8S -> F16 for `cv.LUT()`
 * make `VecVecChar` unmodifible
 * more tests
+* add more functions in `calib3d`
+* make the version of `dartcv4` fixed
 
 ## 1.3.3
 

--- a/packages/opencv_core/images/opencv_core_size_report.svg
+++ b/packages/opencv_core/images/opencv_core_size_report.svg
@@ -46,9 +46,9 @@
         
             <g transform="translate(60, 195)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">71.29 MB</text>
+                <text class="metric-value" x="50" y="15">71.42 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">21.55 MB</text>
+                <text class="metric-value" x="280" y="15">21.68 MB</text>
             </g>
             
         <g transform="translate(40, 260)" filter="url(#dropShadow)">
@@ -65,9 +65,9 @@
         
             <g transform="translate(60, 305)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">86.36 MB</text>
+                <text class="metric-value" x="50" y="15">86.55 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">66.11 MB</text>
+                <text class="metric-value" x="280" y="15">66.30 MB</text>
             </g>
             
         <g transform="translate(40, 370)" filter="url(#dropShadow)">
@@ -85,33 +85,33 @@
                 <g transform="translate(60, 415)">
                     <text class="data-row" x="0" y="15">arm64-v8a</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">18.09 MB</text>
+                    <text class="metric-value" x="250" y="15">18.15 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">11.63 MB</text>
+                    <text class="metric-value" x="500" y="15">11.69 MB</text>
                 </g>
                 
                 <g transform="translate(60, 460)">
                     <text class="data-row" x="0" y="15">armeabi-v7a</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">16.16 MB</text>
+                    <text class="metric-value" x="250" y="15">16.22 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">10.25 MB</text>
+                    <text class="metric-value" x="500" y="15">10.31 MB</text>
                 </g>
                 
                 <g transform="translate(60, 505)">
                     <text class="data-row" x="0" y="15">x86_64</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">20.01 MB</text>
+                    <text class="metric-value" x="250" y="15">20.08 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">13.43 MB</text>
+                    <text class="metric-value" x="500" y="15">13.50 MB</text>
                 </g>
                 
                 <g transform="translate(60, 550)">
                     <text class="data-row" x="0" y="15">full_apk_size</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">52.30 MB</text>
+                    <text class="metric-value" x="250" y="15">52.49 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">34.38 MB</text>
+                    <text class="metric-value" x="500" y="15">34.56 MB</text>
                 </g>
                 
         <g transform="translate(40, 615)" filter="url(#dropShadow)">
@@ -131,9 +131,9 @@
         
             <g transform="translate(60, 660)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">70.78 MB</text>
+                <text class="metric-value" x="50" y="15">71.81 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">47.52 MB</text>
+                <text class="metric-value" x="280" y="15">48.55 MB</text>
             </g>
             
         <g transform="translate(40, 725)" filter="url(#dropShadow)">
@@ -150,8 +150,8 @@
         
             <g transform="translate(60, 770)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">128.32 MB</text>
+                <text class="metric-value" x="50" y="15">128.62 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">84.09 MB</text>
+                <text class="metric-value" x="280" y="15">84.39 MB</text>
             </g>
             </svg>

--- a/packages/opencv_core/pubspec.yaml
+++ b/packages/opencv_core/pubspec.yaml
@@ -5,7 +5,7 @@ description: |
   if you need them, please use `opencv_dart` instead.
 version: 1.3.5
 opencv_version: 4.11.0+0
-dartcv_version: 4.11.0.0
+dartcv_version: 4.11.0.1
 repository: https://github.com/rainyl/opencv_dart
 homepage: https://github.com/rainyl/opencv_dart/tree/main/packages/opencv_core
 

--- a/packages/opencv_core/pubspec.yaml
+++ b/packages/opencv_core/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dartcv4: ^1.1.1
+  dartcv4: 1.1.2
 
 dev_dependencies:
   test: ^1.25.2

--- a/packages/opencv_dart/CHANGELOG.md
+++ b/packages/opencv_dart/CHANGELOG.md
@@ -7,6 +7,8 @@
 * use native implementation of 8U/8S -> F16 for `cv.LUT()`
 * make `VecVecChar` unmodifible
 * more tests
+* add more functions in `calib3d`
+* make the version of `dartcv4` fixed
 
 ## 1.3.3
 

--- a/packages/opencv_dart/images/opencv_dart_size_report.svg
+++ b/packages/opencv_dart/images/opencv_dart_size_report.svg
@@ -46,9 +46,9 @@
         
             <g transform="translate(60, 195)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">71.53 MB</text>
+                <text class="metric-value" x="50" y="15">71.66 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">21.79 MB</text>
+                <text class="metric-value" x="280" y="15">21.91 MB</text>
             </g>
             
         <g transform="translate(40, 260)" filter="url(#dropShadow)">
@@ -65,9 +65,9 @@
         
             <g transform="translate(60, 305)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">203.79 MB</text>
+                <text class="metric-value" x="50" y="15">203.98 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">183.54 MB</text>
+                <text class="metric-value" x="280" y="15">183.73 MB</text>
             </g>
             
         <g transform="translate(40, 370)" filter="url(#dropShadow)">
@@ -85,33 +85,33 @@
                 <g transform="translate(60, 415)">
                     <text class="data-row" x="0" y="15">arm64-v8a</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">21.92 MB</text>
+                    <text class="metric-value" x="250" y="15">21.98 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">15.46 MB</text>
+                    <text class="metric-value" x="500" y="15">15.52 MB</text>
                 </g>
                 
                 <g transform="translate(60, 460)">
                     <text class="data-row" x="0" y="15">armeabi-v7a</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">19.53 MB</text>
+                    <text class="metric-value" x="250" y="15">19.59 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">13.62 MB</text>
+                    <text class="metric-value" x="500" y="15">13.68 MB</text>
                 </g>
                 
                 <g transform="translate(60, 505)">
                     <text class="data-row" x="0" y="15">x86_64</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">24.20 MB</text>
+                    <text class="metric-value" x="250" y="15">24.27 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">17.62 MB</text>
+                    <text class="metric-value" x="500" y="15">17.69 MB</text>
                 </g>
                 
                 <g transform="translate(60, 550)">
                     <text class="data-row" x="0" y="15">full_apk_size</text>
                     <text class="data-row" x="200" y="15">Total: </text>
-                    <text class="metric-value" x="250" y="15">63.69 MB</text>
+                    <text class="metric-value" x="250" y="15">63.87 MB</text>
                     <text class="data-row" x="400" y="15">Package: </text>
-                    <text class="metric-value" x="500" y="15">45.77 MB</text>
+                    <text class="metric-value" x="500" y="15">45.95 MB</text>
                 </g>
                 
         <g transform="translate(40, 615)" filter="url(#dropShadow)">
@@ -131,9 +131,9 @@
         
             <g transform="translate(60, 660)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">176.88 MB</text>
+                <text class="metric-value" x="50" y="15">177.91 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">153.61 MB</text>
+                <text class="metric-value" x="280" y="15">154.65 MB</text>
             </g>
             
         <g transform="translate(40, 725)" filter="url(#dropShadow)">
@@ -150,8 +150,8 @@
         
             <g transform="translate(60, 770)">
                 <text class="data-row" x="0" y="15">Total: </text>
-                <text class="metric-value" x="50" y="15">171.25 MB</text>
+                <text class="metric-value" x="50" y="15">171.54 MB</text>
                 <text class="data-row" x="200" y="15">Package: </text>
-                <text class="metric-value" x="280" y="15">127.03 MB</text>
+                <text class="metric-value" x="280" y="15">127.31 MB</text>
             </g>
             </svg>

--- a/packages/opencv_dart/pubspec.yaml
+++ b/packages/opencv_dart/pubspec.yaml
@@ -5,7 +5,7 @@ description: |
   please use `opencv_core` instead.
 version: 1.3.5
 opencv_version: 4.11.0+0
-dartcv_version: 4.11.0.0
+dartcv_version: 4.11.0.1
 repository: https://github.com/rainyl/opencv_dart
 homepage: https://github.com/rainyl/opencv_dart/tree/main/packages/opencv_dart
 

--- a/packages/opencv_dart/pubspec.yaml
+++ b/packages/opencv_dart/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dartcv4: ^1.1.1
+  dartcv4: 1.1.2
 
 dev_dependencies:
   test: ^1.25.2


### PR DESCRIPTION
fix: #323 

make the version of `dartcv4` fixed (without `^`) in opencv_core and opencv_dart