### PR TITLE
Add `externalSize` option when attaching to help auto disposing

### DIFF
--- a/packages/dartcv/CHANGELOG.md
+++ b/packages/dartcv/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.4
+
+* remove deprecated `MatType.toInt()`, should use MatType.value instead
+* add `MatType.elemSize` `MatType.elemSize1`
+* remove deprecated `(double x, double y, double z).asPoint3f`
+  `(double x, double y).asPoint2f` `(int x, int y).asPoint` `VecPoint.toVecVecPoint`
+
 ## 1.1.3
 
 * add `VideoCapture.grabAsync`

--- a/packages/dartcv/analysis_options.yaml
+++ b/packages/dartcv/analysis_options.yaml
@@ -38,6 +38,9 @@ analyzer:
     missing_return: error
     non_constant_identifier_names: ignore
     parameter_assignments: error
+formatter:
+  pagewidth: 110
+
 linter:
   rules:
     - always_declare_return_types

--- a/packages/dartcv/lib/src/core/cv_vec.dart
+++ b/packages/dartcv/lib/src/core/cv_vec.dart
@@ -25,17 +25,19 @@ class Vec2b extends CvVec<cvg.Vec2b> {
     }
   }
   factory Vec2b(int v1, int v2) {
-    final p = calloc<cvg.Vec2b>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2;
+    final p =
+        calloc<cvg.Vec2b>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2;
     return Vec2b._(p);
   }
 
   factory Vec2b.fromPointer(ffi.Pointer<cvg.Vec2b> ptr, [bool attach = true]) => Vec2b._(ptr, attach);
   factory Vec2b.fromNative(cvg.Vec2b v) {
-    final p = calloc<cvg.Vec2b>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2;
+    final p =
+        calloc<cvg.Vec2b>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2;
     return Vec2b._(p);
   }
 
@@ -78,19 +80,21 @@ class Vec3b extends CvVec<cvg.Vec3b> {
     }
   }
   factory Vec3b(int v1, int v2, int v3) {
-    final p = calloc<cvg.Vec3b>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3;
+    final p =
+        calloc<cvg.Vec3b>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3;
     return Vec3b._(p);
   }
 
   factory Vec3b.fromPointer(ffi.Pointer<cvg.Vec3b> ptr, [bool attach = true]) => Vec3b._(ptr, attach);
   factory Vec3b.fromNative(cvg.Vec3b v) {
-    final p = calloc<cvg.Vec3b>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3;
+    final p =
+        calloc<cvg.Vec3b>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3;
     return Vec3b._(p);
   }
 
@@ -137,21 +141,23 @@ class Vec4b extends CvVec<cvg.Vec4b> {
     }
   }
   factory Vec4b(int v1, int v2, int v3, int v4) {
-    final p = calloc<cvg.Vec4b>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4;
+    final p =
+        calloc<cvg.Vec4b>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4;
     return Vec4b._(p);
   }
 
   factory Vec4b.fromPointer(ffi.Pointer<cvg.Vec4b> ptr, [bool attach = true]) => Vec4b._(ptr, attach);
   factory Vec4b.fromNative(cvg.Vec4b v) {
-    final p = calloc<cvg.Vec4b>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4;
+    final p =
+        calloc<cvg.Vec4b>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4;
     return Vec4b._(p);
   }
 
@@ -202,17 +208,19 @@ class Vec2w extends CvVec<cvg.Vec2w> {
     }
   }
   factory Vec2w(int v1, int v2) {
-    final p = calloc<cvg.Vec2w>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2;
+    final p =
+        calloc<cvg.Vec2w>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2;
     return Vec2w._(p);
   }
 
   factory Vec2w.fromPointer(ffi.Pointer<cvg.Vec2w> ptr, [bool attach = true]) => Vec2w._(ptr, attach);
   factory Vec2w.fromNative(cvg.Vec2w v) {
-    final p = calloc<cvg.Vec2w>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2;
+    final p =
+        calloc<cvg.Vec2w>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2;
     return Vec2w._(p);
   }
 
@@ -255,19 +263,21 @@ class Vec3w extends CvVec<cvg.Vec3w> {
     }
   }
   factory Vec3w(int v1, int v2, int v3) {
-    final p = calloc<cvg.Vec3w>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3;
+    final p =
+        calloc<cvg.Vec3w>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3;
     return Vec3w._(p);
   }
 
   factory Vec3w.fromPointer(ffi.Pointer<cvg.Vec3w> ptr, [bool attach = true]) => Vec3w._(ptr, attach);
   factory Vec3w.fromNative(cvg.Vec3w v) {
-    final p = calloc<cvg.Vec3w>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3;
+    final p =
+        calloc<cvg.Vec3w>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3;
     return Vec3w._(p);
   }
 
@@ -314,21 +324,23 @@ class Vec4w extends CvVec<cvg.Vec4w> {
     }
   }
   factory Vec4w(int v1, int v2, int v3, int v4) {
-    final p = calloc<cvg.Vec4w>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4;
+    final p =
+        calloc<cvg.Vec4w>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4;
     return Vec4w._(p);
   }
 
   factory Vec4w.fromPointer(ffi.Pointer<cvg.Vec4w> ptr, [bool attach = true]) => Vec4w._(ptr, attach);
   factory Vec4w.fromNative(cvg.Vec4w v) {
-    final p = calloc<cvg.Vec4w>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4;
+    final p =
+        calloc<cvg.Vec4w>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4;
     return Vec4w._(p);
   }
   int get val1 => ref.val1;
@@ -378,17 +390,19 @@ class Vec2s extends CvVec<cvg.Vec2s> {
     }
   }
   factory Vec2s(int v1, int v2) {
-    final p = calloc<cvg.Vec2s>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2;
+    final p =
+        calloc<cvg.Vec2s>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2;
     return Vec2s._(p);
   }
 
   factory Vec2s.fromPointer(ffi.Pointer<cvg.Vec2s> ptr, [bool attach = true]) => Vec2s._(ptr, attach);
   factory Vec2s.fromNative(cvg.Vec2s v) {
-    final p = calloc<cvg.Vec2s>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2;
+    final p =
+        calloc<cvg.Vec2s>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2;
     return Vec2s._(p);
   }
   int get val1 => ref.val1;
@@ -430,19 +444,21 @@ class Vec3s extends CvVec<cvg.Vec3s> {
     }
   }
   factory Vec3s(int v1, int v2, int v3) {
-    final p = calloc<cvg.Vec3s>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3;
+    final p =
+        calloc<cvg.Vec3s>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3;
     return Vec3s._(p);
   }
 
   factory Vec3s.fromPointer(ffi.Pointer<cvg.Vec3s> ptr, [bool attach = true]) => Vec3s._(ptr, attach);
   factory Vec3s.fromNative(cvg.Vec3s v) {
-    final p = calloc<cvg.Vec3s>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3;
+    final p =
+        calloc<cvg.Vec3s>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3;
     return Vec3s._(p);
   }
 
@@ -489,21 +505,23 @@ class Vec4s extends CvVec<cvg.Vec4s> {
     }
   }
   factory Vec4s(int v1, int v2, int v3, int v4) {
-    final p = calloc<cvg.Vec4s>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4;
+    final p =
+        calloc<cvg.Vec4s>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4;
     return Vec4s._(p);
   }
 
   factory Vec4s.fromPointer(ffi.Pointer<cvg.Vec4s> ptr, [bool attach = true]) => Vec4s._(ptr, attach);
   factory Vec4s.fromNative(cvg.Vec4s v) {
-    final p = calloc<cvg.Vec4s>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4;
+    final p =
+        calloc<cvg.Vec4s>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4;
     return Vec4s._(p);
   }
 
@@ -554,17 +572,19 @@ class Vec2i extends CvVec<cvg.Vec2i> {
     }
   }
   factory Vec2i(int v1, int v2) {
-    final p = calloc<cvg.Vec2i>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2;
+    final p =
+        calloc<cvg.Vec2i>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2;
     return Vec2i._(p);
   }
 
   factory Vec2i.fromPointer(ffi.Pointer<cvg.Vec2i> ptr, [bool attach = true]) => Vec2i._(ptr, attach);
   factory Vec2i.fromNative(cvg.Vec2i v) {
-    final p = calloc<cvg.Vec2i>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2;
+    final p =
+        calloc<cvg.Vec2i>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2;
     return Vec2i._(p);
   }
 
@@ -607,19 +627,21 @@ class Vec3i extends CvVec<cvg.Vec3i> {
     }
   }
   factory Vec3i(int v1, int v2, int v3) {
-    final p = calloc<cvg.Vec3i>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3;
+    final p =
+        calloc<cvg.Vec3i>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3;
     return Vec3i._(p);
   }
 
   factory Vec3i.fromPointer(ffi.Pointer<cvg.Vec3i> ptr, [bool attach = true]) => Vec3i._(ptr, attach);
   factory Vec3i.fromNative(cvg.Vec3i v) {
-    final p = calloc<cvg.Vec3i>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3;
+    final p =
+        calloc<cvg.Vec3i>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3;
     return Vec3i._(p);
   }
 
@@ -666,21 +688,23 @@ class Vec4i extends CvVec<cvg.Vec4i> {
     }
   }
   factory Vec4i(int v1, int v2, int v3, int v4) {
-    final p = calloc<cvg.Vec4i>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4;
+    final p =
+        calloc<cvg.Vec4i>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4;
     return Vec4i._(p);
   }
 
   factory Vec4i.fromPointer(ffi.Pointer<cvg.Vec4i> ptr, [bool attach = true]) => Vec4i._(ptr, attach);
   factory Vec4i.fromNative(cvg.Vec4i v) {
-    final p = calloc<cvg.Vec4i>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4;
+    final p =
+        calloc<cvg.Vec4i>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4;
     return Vec4i._(p);
   }
 
@@ -731,25 +755,27 @@ class Vec6i extends CvVec<cvg.Vec6i> {
     }
   }
   factory Vec6i(int v1, int v2, int v3, int v4, int v5, int v6) {
-    final p = calloc<cvg.Vec6i>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4
-      ..ref.val5 = v5
-      ..ref.val6 = v6;
+    final p =
+        calloc<cvg.Vec6i>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4
+          ..ref.val5 = v5
+          ..ref.val6 = v6;
     return Vec6i._(p);
   }
 
   factory Vec6i.fromPointer(ffi.Pointer<cvg.Vec6i> ptr, [bool attach = true]) => Vec6i._(ptr, attach);
   factory Vec6i.fromNative(cvg.Vec6i v) {
-    final p = calloc<cvg.Vec6i>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4
-      ..ref.val5 = v.val5
-      ..ref.val6 = v.val6;
+    final p =
+        calloc<cvg.Vec6i>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4
+          ..ref.val5 = v.val5
+          ..ref.val6 = v.val6;
     return Vec6i._(p);
   }
 
@@ -808,29 +834,31 @@ class Vec8i extends CvVec<cvg.Vec8i> {
     }
   }
   factory Vec8i(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8) {
-    final p = calloc<cvg.Vec8i>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4
-      ..ref.val5 = v5
-      ..ref.val6 = v6
-      ..ref.val7 = v7
-      ..ref.val8 = v8;
+    final p =
+        calloc<cvg.Vec8i>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4
+          ..ref.val5 = v5
+          ..ref.val6 = v6
+          ..ref.val7 = v7
+          ..ref.val8 = v8;
     return Vec8i._(p);
   }
 
   factory Vec8i.fromPointer(ffi.Pointer<cvg.Vec8i> ptr, [bool attach = true]) => Vec8i._(ptr, attach);
   factory Vec8i.fromNative(cvg.Vec8i v) {
-    final p = calloc<cvg.Vec8i>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4
-      ..ref.val5 = v.val5
-      ..ref.val6 = v.val6
-      ..ref.val7 = v.val7
-      ..ref.val8 = v.val8;
+    final p =
+        calloc<cvg.Vec8i>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4
+          ..ref.val5 = v.val5
+          ..ref.val6 = v.val6
+          ..ref.val7 = v.val7
+          ..ref.val8 = v.val8;
     return Vec8i._(p);
   }
 
@@ -897,17 +925,19 @@ class Vec2f extends CvVec<cvg.Vec2f> {
     }
   }
   factory Vec2f(double v1, double v2) {
-    final p = calloc<cvg.Vec2f>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2;
+    final p =
+        calloc<cvg.Vec2f>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2;
     return Vec2f._(p);
   }
 
   factory Vec2f.fromPointer(ffi.Pointer<cvg.Vec2f> ptr, [bool attach = true]) => Vec2f._(ptr, attach);
   factory Vec2f.fromNative(cvg.Vec2f v) {
-    final p = calloc<cvg.Vec2f>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2;
+    final p =
+        calloc<cvg.Vec2f>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2;
     return Vec2f._(p);
   }
 
@@ -950,19 +980,21 @@ class Vec3f extends CvVec<cvg.Vec3f> {
     }
   }
   factory Vec3f(double v1, double v2, double v3) {
-    final p = calloc<cvg.Vec3f>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3;
+    final p =
+        calloc<cvg.Vec3f>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3;
     return Vec3f._(p);
   }
 
   factory Vec3f.fromPointer(ffi.Pointer<cvg.Vec3f> ptr, [bool attach = true]) => Vec3f._(ptr, attach);
   factory Vec3f.fromNative(cvg.Vec3f v) {
-    final p = calloc<cvg.Vec3f>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3;
+    final p =
+        calloc<cvg.Vec3f>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3;
     return Vec3f._(p);
   }
 
@@ -1010,21 +1042,23 @@ class Vec4f extends CvVec<cvg.Vec4f> {
     }
   }
   factory Vec4f(double v1, double v2, double v3, double v4) {
-    final p = calloc<cvg.Vec4f>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4;
+    final p =
+        calloc<cvg.Vec4f>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4;
     return Vec4f._(p);
   }
 
   factory Vec4f.fromPointer(ffi.Pointer<cvg.Vec4f> ptr, [bool attach = true]) => Vec4f._(ptr, attach);
   factory Vec4f.fromNative(cvg.Vec4f v) {
-    final p = calloc<cvg.Vec4f>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4;
+    final p =
+        calloc<cvg.Vec4f>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4;
     return Vec4f._(p);
   }
 
@@ -1076,25 +1110,27 @@ class Vec6f extends CvVec<cvg.Vec6f> {
     }
   }
   factory Vec6f(double v1, double v2, double v3, double v4, double v5, double v6) {
-    final p = calloc<cvg.Vec6f>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4
-      ..ref.val5 = v5
-      ..ref.val6 = v6;
+    final p =
+        calloc<cvg.Vec6f>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4
+          ..ref.val5 = v5
+          ..ref.val6 = v6;
     return Vec6f._(p);
   }
 
   factory Vec6f.fromPointer(ffi.Pointer<cvg.Vec6f> ptr, [bool attach = true]) => Vec6f._(ptr, attach);
   factory Vec6f.fromNative(cvg.Vec6f v) {
-    final p = calloc<cvg.Vec6f>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4
-      ..ref.val5 = v.val5
-      ..ref.val6 = v.val6;
+    final p =
+        calloc<cvg.Vec6f>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4
+          ..ref.val5 = v.val5
+          ..ref.val6 = v.val6;
     return Vec6f._(p);
   }
 
@@ -1154,17 +1190,19 @@ class Vec2d extends CvVec<cvg.Vec2d> {
     }
   }
   factory Vec2d(double v1, double v2) {
-    final p = calloc<cvg.Vec2d>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2;
+    final p =
+        calloc<cvg.Vec2d>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2;
     return Vec2d._(p);
   }
 
   factory Vec2d.fromPointer(ffi.Pointer<cvg.Vec2d> ptr, [bool attach = true]) => Vec2d._(ptr, attach);
   factory Vec2d.fromNative(cvg.Vec2d v) {
-    final p = calloc<cvg.Vec2d>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2;
+    final p =
+        calloc<cvg.Vec2d>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2;
     return Vec2d._(p);
   }
 
@@ -1207,19 +1245,21 @@ class Vec3d extends CvVec<cvg.Vec3d> {
     }
   }
   factory Vec3d(double v1, double v2, double v3) {
-    final p = calloc<cvg.Vec3d>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3;
+    final p =
+        calloc<cvg.Vec3d>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3;
     return Vec3d._(p);
   }
 
   factory Vec3d.fromPointer(ffi.Pointer<cvg.Vec3d> ptr, [bool attach = true]) => Vec3d._(ptr, attach);
   factory Vec3d.fromNative(cvg.Vec3d v) {
-    final p = calloc<cvg.Vec3d>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3;
+    final p =
+        calloc<cvg.Vec3d>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3;
     return Vec3d._(p);
   }
 
@@ -1267,21 +1307,23 @@ class Vec4d extends CvVec<cvg.Vec4d> {
     }
   }
   factory Vec4d(double v1, double v2, double v3, double v4) {
-    final p = calloc<cvg.Vec4d>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4;
+    final p =
+        calloc<cvg.Vec4d>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4;
     return Vec4d._(p);
   }
 
   factory Vec4d.fromPointer(ffi.Pointer<cvg.Vec4d> ptr, [bool attach = true]) => Vec4d._(ptr, attach);
   factory Vec4d.fromNative(cvg.Vec4d v) {
-    final p = calloc<cvg.Vec4d>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4;
+    final p =
+        calloc<cvg.Vec4d>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4;
     return Vec4d._(p);
   }
 
@@ -1333,25 +1375,27 @@ class Vec6d extends CvVec<cvg.Vec6d> {
     }
   }
   factory Vec6d(double v1, double v2, double v3, double v4, double v5, double v6) {
-    final p = calloc<cvg.Vec6d>()
-      ..ref.val1 = v1
-      ..ref.val2 = v2
-      ..ref.val3 = v3
-      ..ref.val4 = v4
-      ..ref.val5 = v5
-      ..ref.val6 = v6;
+    final p =
+        calloc<cvg.Vec6d>()
+          ..ref.val1 = v1
+          ..ref.val2 = v2
+          ..ref.val3 = v3
+          ..ref.val4 = v4
+          ..ref.val5 = v5
+          ..ref.val6 = v6;
     return Vec6d._(p);
   }
 
   factory Vec6d.fromPointer(ffi.Pointer<cvg.Vec6d> ptr, [bool attach = true]) => Vec6d._(ptr, attach);
   factory Vec6d.fromNative(cvg.Vec6d v) {
-    final p = calloc<cvg.Vec6d>()
-      ..ref.val1 = v.val1
-      ..ref.val2 = v.val2
-      ..ref.val3 = v.val3
-      ..ref.val4 = v.val4
-      ..ref.val5 = v.val5
-      ..ref.val6 = v.val6;
+    final p =
+        calloc<cvg.Vec6d>()
+          ..ref.val1 = v.val1
+          ..ref.val2 = v.val2
+          ..ref.val3 = v.val3
+          ..ref.val4 = v.val4
+          ..ref.val5 = v.val5
+          ..ref.val6 = v.val6;
     return Vec6d._(p);
   }
 

--- a/packages/dartcv/lib/src/core/cv_vec.dart
+++ b/packages/dartcv/lib/src/core/cv_vec.dart
@@ -1404,13 +1404,13 @@ class Vec6d extends CvVec<cvg.Vec6d> {
 }
 
 class VecVec4i extends Vec<cvg.VecVec4i, Vec4i> {
-  VecVec4i.fromPointer(super.ptr, {bool attach = true, int length = 0}) : super.fromPointer() {
+  VecVec4i.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
       finalizer.attach(
         this,
         ptr.cast<ffi.Void>(),
         detach: this,
-        externalSize: length * ffi.sizeOf<cvg.Vec4i>(),
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.Vec4i>(),
       );
     }
   }
@@ -1492,9 +1492,14 @@ class VecVec4iIterator extends VecIterator<Vec4i> {
 }
 
 class VecVec4f extends Vec<cvg.VecVec4f, Vec4f> {
-  VecVec4f.fromPointer(super.ptr, {bool attach = true, int length = 0}) : super.fromPointer() {
+  VecVec4f.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4f>());
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.Vec4f>(),
+      );
     }
   }
 
@@ -1575,13 +1580,13 @@ class VecVec4fIterator extends VecIterator<Vec4f> {
 }
 
 class VecVec6f extends Vec<cvg.VecVec6f, Vec6f> {
-  VecVec6f.fromPointer(super.ptr, {bool attach = true, int length = 0}) : super.fromPointer() {
+  VecVec6f.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
       finalizer.attach(
         this,
         ptr.cast<ffi.Void>(),
         detach: this,
-        externalSize: length * ffi.sizeOf<cvg.Vec6f>(),
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.Vec6f>(),
       );
     }
   }

--- a/packages/dartcv/lib/src/core/cv_vec.dart
+++ b/packages/dartcv/lib/src/core/cv_vec.dart
@@ -21,23 +21,21 @@ abstract class CvVec<T extends ffi.Struct> extends CvStruct<T> {
 class Vec2b extends CvVec<cvg.Vec2b> {
   Vec2b._(ffi.Pointer<cvg.Vec2b> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec2b>());
     }
   }
   factory Vec2b(int v1, int v2) {
-    final p =
-        calloc<cvg.Vec2b>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2;
+    final p = calloc<cvg.Vec2b>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2;
     return Vec2b._(p);
   }
 
   factory Vec2b.fromPointer(ffi.Pointer<cvg.Vec2b> ptr, [bool attach = true]) => Vec2b._(ptr, attach);
   factory Vec2b.fromNative(cvg.Vec2b v) {
-    final p =
-        calloc<cvg.Vec2b>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2;
+    final p = calloc<cvg.Vec2b>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2;
     return Vec2b._(p);
   }
 
@@ -76,25 +74,23 @@ class Vec2b extends CvVec<cvg.Vec2b> {
 class Vec3b extends CvVec<cvg.Vec3b> {
   Vec3b._(ffi.Pointer<cvg.Vec3b> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec3b>());
     }
   }
   factory Vec3b(int v1, int v2, int v3) {
-    final p =
-        calloc<cvg.Vec3b>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3;
+    final p = calloc<cvg.Vec3b>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3;
     return Vec3b._(p);
   }
 
   factory Vec3b.fromPointer(ffi.Pointer<cvg.Vec3b> ptr, [bool attach = true]) => Vec3b._(ptr, attach);
   factory Vec3b.fromNative(cvg.Vec3b v) {
-    final p =
-        calloc<cvg.Vec3b>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3;
+    final p = calloc<cvg.Vec3b>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3;
     return Vec3b._(p);
   }
 
@@ -137,27 +133,25 @@ class Vec3b extends CvVec<cvg.Vec3b> {
 class Vec4b extends CvVec<cvg.Vec4b> {
   Vec4b._(ffi.Pointer<cvg.Vec4b> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4b>());
     }
   }
   factory Vec4b(int v1, int v2, int v3, int v4) {
-    final p =
-        calloc<cvg.Vec4b>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4;
+    final p = calloc<cvg.Vec4b>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4;
     return Vec4b._(p);
   }
 
   factory Vec4b.fromPointer(ffi.Pointer<cvg.Vec4b> ptr, [bool attach = true]) => Vec4b._(ptr, attach);
   factory Vec4b.fromNative(cvg.Vec4b v) {
-    final p =
-        calloc<cvg.Vec4b>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4;
+    final p = calloc<cvg.Vec4b>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4;
     return Vec4b._(p);
   }
 
@@ -204,23 +198,21 @@ class Vec4b extends CvVec<cvg.Vec4b> {
 class Vec2w extends CvVec<cvg.Vec2w> {
   Vec2w._(ffi.Pointer<cvg.Vec2w> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec2w>());
     }
   }
   factory Vec2w(int v1, int v2) {
-    final p =
-        calloc<cvg.Vec2w>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2;
+    final p = calloc<cvg.Vec2w>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2;
     return Vec2w._(p);
   }
 
   factory Vec2w.fromPointer(ffi.Pointer<cvg.Vec2w> ptr, [bool attach = true]) => Vec2w._(ptr, attach);
   factory Vec2w.fromNative(cvg.Vec2w v) {
-    final p =
-        calloc<cvg.Vec2w>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2;
+    final p = calloc<cvg.Vec2w>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2;
     return Vec2w._(p);
   }
 
@@ -259,25 +251,23 @@ class Vec2w extends CvVec<cvg.Vec2w> {
 class Vec3w extends CvVec<cvg.Vec3w> {
   Vec3w._(ffi.Pointer<cvg.Vec3w> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec3w>());
     }
   }
   factory Vec3w(int v1, int v2, int v3) {
-    final p =
-        calloc<cvg.Vec3w>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3;
+    final p = calloc<cvg.Vec3w>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3;
     return Vec3w._(p);
   }
 
   factory Vec3w.fromPointer(ffi.Pointer<cvg.Vec3w> ptr, [bool attach = true]) => Vec3w._(ptr, attach);
   factory Vec3w.fromNative(cvg.Vec3w v) {
-    final p =
-        calloc<cvg.Vec3w>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3;
+    final p = calloc<cvg.Vec3w>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3;
     return Vec3w._(p);
   }
 
@@ -320,27 +310,25 @@ class Vec3w extends CvVec<cvg.Vec3w> {
 class Vec4w extends CvVec<cvg.Vec4w> {
   Vec4w._(ffi.Pointer<cvg.Vec4w> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4w>());
     }
   }
   factory Vec4w(int v1, int v2, int v3, int v4) {
-    final p =
-        calloc<cvg.Vec4w>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4;
+    final p = calloc<cvg.Vec4w>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4;
     return Vec4w._(p);
   }
 
   factory Vec4w.fromPointer(ffi.Pointer<cvg.Vec4w> ptr, [bool attach = true]) => Vec4w._(ptr, attach);
   factory Vec4w.fromNative(cvg.Vec4w v) {
-    final p =
-        calloc<cvg.Vec4w>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4;
+    final p = calloc<cvg.Vec4w>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4;
     return Vec4w._(p);
   }
   int get val1 => ref.val1;
@@ -386,23 +374,21 @@ class Vec4w extends CvVec<cvg.Vec4w> {
 class Vec2s extends CvVec<cvg.Vec2s> {
   Vec2s._(ffi.Pointer<cvg.Vec2s> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec2s>());
     }
   }
   factory Vec2s(int v1, int v2) {
-    final p =
-        calloc<cvg.Vec2s>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2;
+    final p = calloc<cvg.Vec2s>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2;
     return Vec2s._(p);
   }
 
   factory Vec2s.fromPointer(ffi.Pointer<cvg.Vec2s> ptr, [bool attach = true]) => Vec2s._(ptr, attach);
   factory Vec2s.fromNative(cvg.Vec2s v) {
-    final p =
-        calloc<cvg.Vec2s>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2;
+    final p = calloc<cvg.Vec2s>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2;
     return Vec2s._(p);
   }
   int get val1 => ref.val1;
@@ -440,25 +426,23 @@ class Vec2s extends CvVec<cvg.Vec2s> {
 class Vec3s extends CvVec<cvg.Vec3s> {
   Vec3s._(ffi.Pointer<cvg.Vec3s> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec3s>());
     }
   }
   factory Vec3s(int v1, int v2, int v3) {
-    final p =
-        calloc<cvg.Vec3s>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3;
+    final p = calloc<cvg.Vec3s>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3;
     return Vec3s._(p);
   }
 
   factory Vec3s.fromPointer(ffi.Pointer<cvg.Vec3s> ptr, [bool attach = true]) => Vec3s._(ptr, attach);
   factory Vec3s.fromNative(cvg.Vec3s v) {
-    final p =
-        calloc<cvg.Vec3s>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3;
+    final p = calloc<cvg.Vec3s>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3;
     return Vec3s._(p);
   }
 
@@ -501,27 +485,25 @@ class Vec3s extends CvVec<cvg.Vec3s> {
 class Vec4s extends CvVec<cvg.Vec4s> {
   Vec4s._(ffi.Pointer<cvg.Vec4s> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4s>());
     }
   }
   factory Vec4s(int v1, int v2, int v3, int v4) {
-    final p =
-        calloc<cvg.Vec4s>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4;
+    final p = calloc<cvg.Vec4s>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4;
     return Vec4s._(p);
   }
 
   factory Vec4s.fromPointer(ffi.Pointer<cvg.Vec4s> ptr, [bool attach = true]) => Vec4s._(ptr, attach);
   factory Vec4s.fromNative(cvg.Vec4s v) {
-    final p =
-        calloc<cvg.Vec4s>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4;
+    final p = calloc<cvg.Vec4s>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4;
     return Vec4s._(p);
   }
 
@@ -568,23 +550,21 @@ class Vec4s extends CvVec<cvg.Vec4s> {
 class Vec2i extends CvVec<cvg.Vec2i> {
   Vec2i._(ffi.Pointer<cvg.Vec2i> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec2i>());
     }
   }
   factory Vec2i(int v1, int v2) {
-    final p =
-        calloc<cvg.Vec2i>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2;
+    final p = calloc<cvg.Vec2i>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2;
     return Vec2i._(p);
   }
 
   factory Vec2i.fromPointer(ffi.Pointer<cvg.Vec2i> ptr, [bool attach = true]) => Vec2i._(ptr, attach);
   factory Vec2i.fromNative(cvg.Vec2i v) {
-    final p =
-        calloc<cvg.Vec2i>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2;
+    final p = calloc<cvg.Vec2i>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2;
     return Vec2i._(p);
   }
 
@@ -623,25 +603,23 @@ class Vec2i extends CvVec<cvg.Vec2i> {
 class Vec3i extends CvVec<cvg.Vec3i> {
   Vec3i._(ffi.Pointer<cvg.Vec3i> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec3i>());
     }
   }
   factory Vec3i(int v1, int v2, int v3) {
-    final p =
-        calloc<cvg.Vec3i>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3;
+    final p = calloc<cvg.Vec3i>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3;
     return Vec3i._(p);
   }
 
   factory Vec3i.fromPointer(ffi.Pointer<cvg.Vec3i> ptr, [bool attach = true]) => Vec3i._(ptr, attach);
   factory Vec3i.fromNative(cvg.Vec3i v) {
-    final p =
-        calloc<cvg.Vec3i>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3;
+    final p = calloc<cvg.Vec3i>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3;
     return Vec3i._(p);
   }
 
@@ -684,27 +662,25 @@ class Vec3i extends CvVec<cvg.Vec3i> {
 class Vec4i extends CvVec<cvg.Vec4i> {
   Vec4i._(ffi.Pointer<cvg.Vec4i> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4i>());
     }
   }
   factory Vec4i(int v1, int v2, int v3, int v4) {
-    final p =
-        calloc<cvg.Vec4i>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4;
+    final p = calloc<cvg.Vec4i>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4;
     return Vec4i._(p);
   }
 
   factory Vec4i.fromPointer(ffi.Pointer<cvg.Vec4i> ptr, [bool attach = true]) => Vec4i._(ptr, attach);
   factory Vec4i.fromNative(cvg.Vec4i v) {
-    final p =
-        calloc<cvg.Vec4i>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4;
+    final p = calloc<cvg.Vec4i>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4;
     return Vec4i._(p);
   }
 
@@ -751,31 +727,29 @@ class Vec4i extends CvVec<cvg.Vec4i> {
 class Vec6i extends CvVec<cvg.Vec6i> {
   Vec6i._(ffi.Pointer<cvg.Vec6i> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec6i>());
     }
   }
   factory Vec6i(int v1, int v2, int v3, int v4, int v5, int v6) {
-    final p =
-        calloc<cvg.Vec6i>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4
-          ..ref.val5 = v5
-          ..ref.val6 = v6;
+    final p = calloc<cvg.Vec6i>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4
+      ..ref.val5 = v5
+      ..ref.val6 = v6;
     return Vec6i._(p);
   }
 
   factory Vec6i.fromPointer(ffi.Pointer<cvg.Vec6i> ptr, [bool attach = true]) => Vec6i._(ptr, attach);
   factory Vec6i.fromNative(cvg.Vec6i v) {
-    final p =
-        calloc<cvg.Vec6i>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4
-          ..ref.val5 = v.val5
-          ..ref.val6 = v.val6;
+    final p = calloc<cvg.Vec6i>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4
+      ..ref.val5 = v.val5
+      ..ref.val6 = v.val6;
     return Vec6i._(p);
   }
 
@@ -830,35 +804,33 @@ class Vec6i extends CvVec<cvg.Vec6i> {
 class Vec8i extends CvVec<cvg.Vec8i> {
   Vec8i._(ffi.Pointer<cvg.Vec8i> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec8i>());
     }
   }
   factory Vec8i(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8) {
-    final p =
-        calloc<cvg.Vec8i>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4
-          ..ref.val5 = v5
-          ..ref.val6 = v6
-          ..ref.val7 = v7
-          ..ref.val8 = v8;
+    final p = calloc<cvg.Vec8i>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4
+      ..ref.val5 = v5
+      ..ref.val6 = v6
+      ..ref.val7 = v7
+      ..ref.val8 = v8;
     return Vec8i._(p);
   }
 
   factory Vec8i.fromPointer(ffi.Pointer<cvg.Vec8i> ptr, [bool attach = true]) => Vec8i._(ptr, attach);
   factory Vec8i.fromNative(cvg.Vec8i v) {
-    final p =
-        calloc<cvg.Vec8i>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4
-          ..ref.val5 = v.val5
-          ..ref.val6 = v.val6
-          ..ref.val7 = v.val7
-          ..ref.val8 = v.val8;
+    final p = calloc<cvg.Vec8i>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4
+      ..ref.val5 = v.val5
+      ..ref.val6 = v.val6
+      ..ref.val7 = v.val7
+      ..ref.val8 = v.val8;
     return Vec8i._(p);
   }
 
@@ -921,23 +893,21 @@ class Vec8i extends CvVec<cvg.Vec8i> {
 class Vec2f extends CvVec<cvg.Vec2f> {
   Vec2f._(ffi.Pointer<cvg.Vec2f> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec2f>());
     }
   }
   factory Vec2f(double v1, double v2) {
-    final p =
-        calloc<cvg.Vec2f>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2;
+    final p = calloc<cvg.Vec2f>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2;
     return Vec2f._(p);
   }
 
   factory Vec2f.fromPointer(ffi.Pointer<cvg.Vec2f> ptr, [bool attach = true]) => Vec2f._(ptr, attach);
   factory Vec2f.fromNative(cvg.Vec2f v) {
-    final p =
-        calloc<cvg.Vec2f>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2;
+    final p = calloc<cvg.Vec2f>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2;
     return Vec2f._(p);
   }
 
@@ -976,25 +946,23 @@ class Vec2f extends CvVec<cvg.Vec2f> {
 class Vec3f extends CvVec<cvg.Vec3f> {
   Vec3f._(ffi.Pointer<cvg.Vec3f> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec3f>());
     }
   }
   factory Vec3f(double v1, double v2, double v3) {
-    final p =
-        calloc<cvg.Vec3f>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3;
+    final p = calloc<cvg.Vec3f>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3;
     return Vec3f._(p);
   }
 
   factory Vec3f.fromPointer(ffi.Pointer<cvg.Vec3f> ptr, [bool attach = true]) => Vec3f._(ptr, attach);
   factory Vec3f.fromNative(cvg.Vec3f v) {
-    final p =
-        calloc<cvg.Vec3f>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3;
+    final p = calloc<cvg.Vec3f>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3;
     return Vec3f._(p);
   }
 
@@ -1038,27 +1006,25 @@ class Vec3f extends CvVec<cvg.Vec3f> {
 class Vec4f extends CvVec<cvg.Vec4f> {
   Vec4f._(ffi.Pointer<cvg.Vec4f> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4f>());
     }
   }
   factory Vec4f(double v1, double v2, double v3, double v4) {
-    final p =
-        calloc<cvg.Vec4f>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4;
+    final p = calloc<cvg.Vec4f>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4;
     return Vec4f._(p);
   }
 
   factory Vec4f.fromPointer(ffi.Pointer<cvg.Vec4f> ptr, [bool attach = true]) => Vec4f._(ptr, attach);
   factory Vec4f.fromNative(cvg.Vec4f v) {
-    final p =
-        calloc<cvg.Vec4f>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4;
+    final p = calloc<cvg.Vec4f>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4;
     return Vec4f._(p);
   }
 
@@ -1106,31 +1072,29 @@ class Vec4f extends CvVec<cvg.Vec4f> {
 class Vec6f extends CvVec<cvg.Vec6f> {
   Vec6f._(ffi.Pointer<cvg.Vec6f> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec6f>());
     }
   }
   factory Vec6f(double v1, double v2, double v3, double v4, double v5, double v6) {
-    final p =
-        calloc<cvg.Vec6f>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4
-          ..ref.val5 = v5
-          ..ref.val6 = v6;
+    final p = calloc<cvg.Vec6f>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4
+      ..ref.val5 = v5
+      ..ref.val6 = v6;
     return Vec6f._(p);
   }
 
   factory Vec6f.fromPointer(ffi.Pointer<cvg.Vec6f> ptr, [bool attach = true]) => Vec6f._(ptr, attach);
   factory Vec6f.fromNative(cvg.Vec6f v) {
-    final p =
-        calloc<cvg.Vec6f>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4
-          ..ref.val5 = v.val5
-          ..ref.val6 = v.val6;
+    final p = calloc<cvg.Vec6f>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4
+      ..ref.val5 = v.val5
+      ..ref.val6 = v.val6;
     return Vec6f._(p);
   }
 
@@ -1186,23 +1150,21 @@ class Vec6f extends CvVec<cvg.Vec6f> {
 class Vec2d extends CvVec<cvg.Vec2d> {
   Vec2d._(ffi.Pointer<cvg.Vec2d> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec2d>());
     }
   }
   factory Vec2d(double v1, double v2) {
-    final p =
-        calloc<cvg.Vec2d>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2;
+    final p = calloc<cvg.Vec2d>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2;
     return Vec2d._(p);
   }
 
   factory Vec2d.fromPointer(ffi.Pointer<cvg.Vec2d> ptr, [bool attach = true]) => Vec2d._(ptr, attach);
   factory Vec2d.fromNative(cvg.Vec2d v) {
-    final p =
-        calloc<cvg.Vec2d>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2;
+    final p = calloc<cvg.Vec2d>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2;
     return Vec2d._(p);
   }
 
@@ -1241,25 +1203,23 @@ class Vec2d extends CvVec<cvg.Vec2d> {
 class Vec3d extends CvVec<cvg.Vec3d> {
   Vec3d._(ffi.Pointer<cvg.Vec3d> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec3d>());
     }
   }
   factory Vec3d(double v1, double v2, double v3) {
-    final p =
-        calloc<cvg.Vec3d>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3;
+    final p = calloc<cvg.Vec3d>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3;
     return Vec3d._(p);
   }
 
   factory Vec3d.fromPointer(ffi.Pointer<cvg.Vec3d> ptr, [bool attach = true]) => Vec3d._(ptr, attach);
   factory Vec3d.fromNative(cvg.Vec3d v) {
-    final p =
-        calloc<cvg.Vec3d>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3;
+    final p = calloc<cvg.Vec3d>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3;
     return Vec3d._(p);
   }
 
@@ -1303,27 +1263,25 @@ class Vec3d extends CvVec<cvg.Vec3d> {
 class Vec4d extends CvVec<cvg.Vec4d> {
   Vec4d._(ffi.Pointer<cvg.Vec4d> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4d>());
     }
   }
   factory Vec4d(double v1, double v2, double v3, double v4) {
-    final p =
-        calloc<cvg.Vec4d>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4;
+    final p = calloc<cvg.Vec4d>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4;
     return Vec4d._(p);
   }
 
   factory Vec4d.fromPointer(ffi.Pointer<cvg.Vec4d> ptr, [bool attach = true]) => Vec4d._(ptr, attach);
   factory Vec4d.fromNative(cvg.Vec4d v) {
-    final p =
-        calloc<cvg.Vec4d>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4;
+    final p = calloc<cvg.Vec4d>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4;
     return Vec4d._(p);
   }
 
@@ -1371,31 +1329,29 @@ class Vec4d extends CvVec<cvg.Vec4d> {
 class Vec6d extends CvVec<cvg.Vec6d> {
   Vec6d._(ffi.Pointer<cvg.Vec6d> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Vec6d>());
     }
   }
   factory Vec6d(double v1, double v2, double v3, double v4, double v5, double v6) {
-    final p =
-        calloc<cvg.Vec6d>()
-          ..ref.val1 = v1
-          ..ref.val2 = v2
-          ..ref.val3 = v3
-          ..ref.val4 = v4
-          ..ref.val5 = v5
-          ..ref.val6 = v6;
+    final p = calloc<cvg.Vec6d>()
+      ..ref.val1 = v1
+      ..ref.val2 = v2
+      ..ref.val3 = v3
+      ..ref.val4 = v4
+      ..ref.val5 = v5
+      ..ref.val6 = v6;
     return Vec6d._(p);
   }
 
   factory Vec6d.fromPointer(ffi.Pointer<cvg.Vec6d> ptr, [bool attach = true]) => Vec6d._(ptr, attach);
   factory Vec6d.fromNative(cvg.Vec6d v) {
-    final p =
-        calloc<cvg.Vec6d>()
-          ..ref.val1 = v.val1
-          ..ref.val2 = v.val2
-          ..ref.val3 = v.val3
-          ..ref.val4 = v.val4
-          ..ref.val5 = v.val5
-          ..ref.val6 = v.val6;
+    final p = calloc<cvg.Vec6d>()
+      ..ref.val1 = v.val1
+      ..ref.val2 = v.val2
+      ..ref.val3 = v.val3
+      ..ref.val4 = v.val4
+      ..ref.val5 = v.val5
+      ..ref.val6 = v.val6;
     return Vec6d._(p);
   }
 
@@ -1448,13 +1404,18 @@ class Vec6d extends CvVec<cvg.Vec6d> {
 }
 
 class VecVec4i extends Vec<cvg.VecVec4i, Vec4i> {
-  VecVec4i.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVec4i.fromPointer(super.ptr, {bool attach = true, int length = 0}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length * ffi.sizeOf<cvg.Vec4i>(),
+      );
     }
   }
 
-  factory VecVec4i([int length = 0]) => VecVec4i.fromPointer(ccore.std_VecVec4i_new(length));
+  factory VecVec4i([int length = 0]) => VecVec4i.fromPointer(ccore.std_VecVec4i_new(length), length: length);
 
   factory VecVec4i.fromList(List<Vec4i> pts) => VecVec4i.generate(pts.length, (i) => pts[i], dispose: false);
 
@@ -1465,7 +1426,7 @@ class VecVec4i extends Vec<cvg.VecVec4i, Vec4i> {
       ccore.std_VecVec4i_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecVec4i.fromPointer(p);
+    return VecVec4i.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVec4iPtr>(ccore.addresses.std_VecVec4i_free);
@@ -1531,13 +1492,13 @@ class VecVec4iIterator extends VecIterator<Vec4i> {
 }
 
 class VecVec4f extends Vec<cvg.VecVec4f, Vec4f> {
-  VecVec4f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVec4f.fromPointer(super.ptr, {bool attach = true, int length = 0}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: ffi.sizeOf<cvg.Vec4f>());
     }
   }
 
-  factory VecVec4f([int length = 0]) => VecVec4f.fromPointer(ccore.std_VecVec4f_new(length));
+  factory VecVec4f([int length = 0]) => VecVec4f.fromPointer(ccore.std_VecVec4f_new(length), length: length);
 
   factory VecVec4f.fromList(List<Vec4f> pts) => VecVec4f.generate(pts.length, (i) => pts[i], dispose: false);
 
@@ -1548,7 +1509,7 @@ class VecVec4f extends Vec<cvg.VecVec4f, Vec4f> {
       ccore.std_VecVec4f_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecVec4f.fromPointer(p);
+    return VecVec4f.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVec4fPtr>(ccore.addresses.std_VecVec4f_free);
@@ -1614,13 +1575,18 @@ class VecVec4fIterator extends VecIterator<Vec4f> {
 }
 
 class VecVec6f extends Vec<cvg.VecVec6f, Vec6f> {
-  VecVec6f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVec6f.fromPointer(super.ptr, {bool attach = true, int length = 0}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length * ffi.sizeOf<cvg.Vec6f>(),
+      );
     }
   }
 
-  factory VecVec6f([int length = 0]) => VecVec6f.fromPointer(ccore.std_VecVec6f_new(length));
+  factory VecVec6f([int length = 0]) => VecVec6f.fromPointer(ccore.std_VecVec6f_new(length), length: length);
 
   factory VecVec6f.fromList(List<Vec6f> pts) => VecVec6f.generate(pts.length, (i) => pts[i], dispose: false);
 
@@ -1631,7 +1597,7 @@ class VecVec6f extends Vec<cvg.VecVec6f, Vec6f> {
       ccore.std_VecVec6f_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecVec6f.fromPointer(p);
+    return VecVec6f.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVec4fPtr>(ccore.addresses.std_VecVec4f_free);

--- a/packages/dartcv/lib/src/core/dmatch.dart
+++ b/packages/dartcv/lib/src/core/dmatch.dart
@@ -14,9 +14,9 @@ import 'base.dart';
 import 'vec.dart';
 
 class DMatch extends CvStruct<cvg.DMatch> {
-  DMatch._(ffi.Pointer<cvg.DMatch> ptr, {bool attach = true, int? externalSize}) : super.fromPointer(ptr) {
+  DMatch._(ffi.Pointer<cvg.DMatch> ptr, {bool attach = true}) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this, externalSize: externalSize);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.DMatch>());
     }
   }
   factory DMatch(int queryIdx, int trainIdx, int imgIdx, double distance) {
@@ -25,11 +25,10 @@ class DMatch extends CvStruct<cvg.DMatch> {
       ..ref.trainIdx = trainIdx
       ..ref.imgIdx = imgIdx
       ..ref.distance = distance;
-    return DMatch._(ptr, externalSize: ffi.sizeOf<cvg.DMatch>());
+    return DMatch._(ptr);
   }
   factory DMatch.fromNative(cvg.DMatch r) => DMatch(r.queryIdx, r.trainIdx, r.imgIdx, r.distance);
-  factory DMatch.fromPointer(ffi.Pointer<cvg.DMatch> p, {bool attach = true, int? externalSize}) =>
-      DMatch._(p, attach: attach, externalSize: externalSize);
+  factory DMatch.fromPointer(ffi.Pointer<cvg.DMatch> p, {bool attach = true}) => DMatch._(p, attach: attach);
 
   static final finalizer = ffi.NativeFinalizer(calloc.nativeFree);
 

--- a/packages/dartcv/lib/src/core/dmatch.dart
+++ b/packages/dartcv/lib/src/core/dmatch.dart
@@ -14,22 +14,22 @@ import 'base.dart';
 import 'vec.dart';
 
 class DMatch extends CvStruct<cvg.DMatch> {
-  DMatch._(ffi.Pointer<cvg.DMatch> ptr, [bool attach = true]) : super.fromPointer(ptr) {
+  DMatch._(ffi.Pointer<cvg.DMatch> ptr, {bool attach = true, int? externalSize}) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: externalSize);
     }
   }
   factory DMatch(int queryIdx, int trainIdx, int imgIdx, double distance) {
-    final ptr =
-        calloc<cvg.DMatch>()
-          ..ref.queryIdx = queryIdx
-          ..ref.trainIdx = trainIdx
-          ..ref.imgIdx = imgIdx
-          ..ref.distance = distance;
-    return DMatch._(ptr);
+    final ptr = calloc<cvg.DMatch>()
+      ..ref.queryIdx = queryIdx
+      ..ref.trainIdx = trainIdx
+      ..ref.imgIdx = imgIdx
+      ..ref.distance = distance;
+    return DMatch._(ptr, externalSize: ffi.sizeOf<cvg.DMatch>());
   }
   factory DMatch.fromNative(cvg.DMatch r) => DMatch(r.queryIdx, r.trainIdx, r.imgIdx, r.distance);
-  factory DMatch.fromPointer(ffi.Pointer<cvg.DMatch> p, [bool attach = true]) => DMatch._(p, attach);
+  factory DMatch.fromPointer(ffi.Pointer<cvg.DMatch> p, {bool attach = true, int? externalSize}) =>
+      DMatch._(p, attach: attach, externalSize: externalSize);
 
   static final finalizer = ffi.NativeFinalizer(calloc.nativeFree);
 
@@ -60,13 +60,14 @@ class DMatch extends CvStruct<cvg.DMatch> {
 }
 
 class VecDMatch extends Vec<cvg.VecDMatch, DMatch> {
-  VecDMatch.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecDMatch.fromPointer(super.ptr, {bool attach = true, int? externalSize}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: externalSize);
     }
   }
 
-  factory VecDMatch([int length = 0]) => VecDMatch.fromPointer(ccore.std_VecDMatch_new(length));
+  factory VecDMatch([int length = 0]) =>
+      VecDMatch.fromPointer(ccore.std_VecDMatch_new(length), externalSize: length * ffi.sizeOf<cvg.DMatch>());
 
   factory VecDMatch.fromList(List<DMatch> pts) =>
       VecDMatch.generate(pts.length, (i) => pts[i], dispose: false);
@@ -78,7 +79,7 @@ class VecDMatch extends Vec<cvg.VecDMatch, DMatch> {
       ccore.std_VecDMatch_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecDMatch.fromPointer(p);
+    return VecDMatch.fromPointer(p, externalSize: length * ffi.sizeOf<cvg.DMatch>());
   }
 
   static final finalizer = OcvFinalizer<cvg.VecDMatchPtr>(ccore.addresses.std_VecDMatch_free);
@@ -144,25 +145,30 @@ class VecDMatchIterator extends VecIterator<DMatch> {
 }
 
 class VecVecDMatch extends VecUnmodifible<cvg.VecVecDMatch, VecDMatch> {
-  VecVecDMatch.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVecDMatch.fromPointer(super.ptr, {bool attach = true, int? externalSize}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: externalSize);
     }
   }
 
-  factory VecVecDMatch([int length = 0]) => VecVecDMatch.fromPointer(ccore.std_VecVecDMatch_new(length));
+  factory VecVecDMatch([int length = 0]) => VecVecDMatch.fromPointer(
+        ccore.std_VecVecDMatch_new(length),
+        externalSize: length * ffi.sizeOf<cvg.VecDMatch>(), // TODO: this is not accurate
+      );
 
   factory VecVecDMatch.fromList(List<List<DMatch>> pts) =>
       VecVecDMatch.generate(pts.length, (i) => VecDMatch.fromList(pts[i]), dispose: false);
 
   factory VecVecDMatch.generate(int length, VecDMatch Function(int i) generator, {bool dispose = true}) {
     final p = ccore.std_VecVecDMatch_new(length);
+    int count = 0;
     for (var i = 0; i < length; i++) {
       final v = generator(i);
+      count += v.length;
       ccore.std_VecVecDMatch_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecVecDMatch.fromPointer(p);
+    return VecVecDMatch.fromPointer(p, externalSize: count * ffi.sizeOf<cvg.DMatch>());
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVecDMatchPtr>(ccore.addresses.std_VecVecDMatch_free);
@@ -191,15 +197,16 @@ class VecVecDMatch extends VecUnmodifible<cvg.VecVecDMatch, VecDMatch> {
   ffi.Pointer<ffi.Void> asVoid() => ref.ptr.cast<ffi.Void>();
 
   @override
-  VecDMatch operator [](int idx) => VecDMatch.fromPointer(ccore.std_VecVecDMatch_get_p(ptr, idx), false);
+  VecDMatch operator [](int idx) =>
+      VecDMatch.fromPointer(ccore.std_VecVecDMatch_get_p(ptr, idx), attach: false);
 
   List<List<DMatch>> copyToList() => List.generate(
-    length,
-    (i) => List.generate(
-      ccore.std_VecVecDMatch_length_i(ptr, i),
-      (j) => DMatch.fromPointer(ccore.std_VecVecDMatch_get_ij(ptr, i, j)),
-    ),
-  );
+        length,
+        (i) => List.generate(
+          ccore.std_VecVecDMatch_length_i(ptr, i),
+          (j) => DMatch.fromPointer(ccore.std_VecVecDMatch_get_ij(ptr, i, j)),
+        ),
+      );
 }
 
 class VecVecDMatchIterator extends VecIterator<VecDMatch> {
@@ -210,7 +217,8 @@ class VecVecDMatchIterator extends VecIterator<VecDMatch> {
   int get length => ccore.std_VecVecDMatch_length(ptr);
 
   @override
-  VecDMatch operator [](int idx) => VecDMatch.fromPointer(ccore.std_VecVecDMatch_get_p(ptr, idx), false);
+  VecDMatch operator [](int idx) =>
+      VecDMatch.fromPointer(ccore.std_VecVecDMatch_get_p(ptr, idx), attach: false);
 }
 
 extension ListDMatchExtension on List<DMatch> {

--- a/packages/dartcv/lib/src/core/dmatch.dart
+++ b/packages/dartcv/lib/src/core/dmatch.dart
@@ -20,11 +20,12 @@ class DMatch extends CvStruct<cvg.DMatch> {
     }
   }
   factory DMatch(int queryIdx, int trainIdx, int imgIdx, double distance) {
-    final ptr = calloc<cvg.DMatch>()
-      ..ref.queryIdx = queryIdx
-      ..ref.trainIdx = trainIdx
-      ..ref.imgIdx = imgIdx
-      ..ref.distance = distance;
+    final ptr =
+        calloc<cvg.DMatch>()
+          ..ref.queryIdx = queryIdx
+          ..ref.trainIdx = trainIdx
+          ..ref.imgIdx = imgIdx
+          ..ref.distance = distance;
     return DMatch._(ptr);
   }
   factory DMatch.fromNative(cvg.DMatch r) => DMatch(r.queryIdx, r.trainIdx, r.imgIdx, r.distance);
@@ -151,9 +152,9 @@ class VecVecDMatch extends VecUnmodifible<cvg.VecVecDMatch, VecDMatch> {
   }
 
   factory VecVecDMatch([int length = 0]) => VecVecDMatch.fromPointer(
-        ccore.std_VecVecDMatch_new(length),
-        externalSize: length * ffi.sizeOf<cvg.VecDMatch>(), // TODO: this is not accurate
-      );
+    ccore.std_VecVecDMatch_new(length),
+    externalSize: length * ffi.sizeOf<cvg.VecDMatch>(), // TODO: this is not accurate
+  );
 
   factory VecVecDMatch.fromList(List<List<DMatch>> pts) =>
       VecVecDMatch.generate(pts.length, (i) => VecDMatch.fromList(pts[i]), dispose: false);
@@ -200,12 +201,12 @@ class VecVecDMatch extends VecUnmodifible<cvg.VecVecDMatch, VecDMatch> {
       VecDMatch.fromPointer(ccore.std_VecVecDMatch_get_p(ptr, idx), attach: false);
 
   List<List<DMatch>> copyToList() => List.generate(
-        length,
-        (i) => List.generate(
-          ccore.std_VecVecDMatch_length_i(ptr, i),
-          (j) => DMatch.fromPointer(ccore.std_VecVecDMatch_get_ij(ptr, i, j)),
-        ),
-      );
+    length,
+    (i) => List.generate(
+      ccore.std_VecVecDMatch_length_i(ptr, i),
+      (j) => DMatch.fromPointer(ccore.std_VecVecDMatch_get_ij(ptr, i, j)),
+    ),
+  );
 }
 
 class VecVecDMatchIterator extends VecIterator<VecDMatch> {

--- a/packages/dartcv/lib/src/core/keypoint.dart
+++ b/packages/dartcv/lib/src/core/keypoint.dart
@@ -14,26 +14,26 @@ import 'base.dart';
 import 'vec.dart';
 
 class KeyPoint extends CvStruct<cvg.KeyPoint> {
-  KeyPoint._(ffi.Pointer<cvg.KeyPoint> ptr, [bool attach = true]) : super.fromPointer(ptr) {
+  KeyPoint._(ffi.Pointer<cvg.KeyPoint> ptr, {bool attach = true}) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.KeyPoint>());
     }
   }
   factory KeyPoint(double x, double y, double size, double angle, double response, int octave, int classID) {
-    final ptr =
-        calloc<cvg.KeyPoint>()
-          ..ref.x = x
-          ..ref.y = y
-          ..ref.size = size
-          ..ref.angle = angle
-          ..ref.response = response
-          ..ref.octave = octave
-          ..ref.classID = classID;
+    final ptr = calloc<cvg.KeyPoint>()
+      ..ref.x = x
+      ..ref.y = y
+      ..ref.size = size
+      ..ref.angle = angle
+      ..ref.response = response
+      ..ref.octave = octave
+      ..ref.classID = classID;
     return KeyPoint._(ptr);
   }
   factory KeyPoint.fromNative(cvg.KeyPoint r) =>
       KeyPoint(r.x, r.y, r.size, r.angle, r.response, r.octave, r.classID);
-  factory KeyPoint.fromPointer(ffi.Pointer<cvg.KeyPoint> p, [bool attach = true]) => KeyPoint._(p, attach);
+  factory KeyPoint.fromPointer(ffi.Pointer<cvg.KeyPoint> p, {bool attach = true}) =>
+      KeyPoint._(p, attach: attach);
 
   static final finalizer = ffi.NativeFinalizer(calloc.nativeFree);
 
@@ -69,8 +69,7 @@ class KeyPoint extends CvStruct<cvg.KeyPoint> {
   @override
   cvg.KeyPoint get ref => ptr.ref;
   @override
-  String toString() =>
-      "KeyPoint("
+  String toString() => "KeyPoint("
       "${x.toStringAsFixed(3)}, "
       "${y.toStringAsFixed(3)}, "
       "${size.toStringAsFixed(3)}, "
@@ -80,13 +79,19 @@ class KeyPoint extends CvStruct<cvg.KeyPoint> {
 }
 
 class VecKeyPoint extends Vec<cvg.VecKeyPoint, KeyPoint> {
-  VecKeyPoint.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecKeyPoint.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.KeyPoint>(),
+      );
     }
   }
 
-  factory VecKeyPoint([int length = 0]) => VecKeyPoint.fromPointer(ccore.std_VecKeyPoint_new(length));
+  factory VecKeyPoint([int length = 0]) =>
+      VecKeyPoint.fromPointer(ccore.std_VecKeyPoint_new(length), length: length);
 
   factory VecKeyPoint.fromList(List<KeyPoint> pts) =>
       VecKeyPoint.generate(pts.length, (i) => pts[i], dispose: false);
@@ -98,7 +103,7 @@ class VecKeyPoint extends Vec<cvg.VecKeyPoint, KeyPoint> {
       ccore.std_VecKeyPoint_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecKeyPoint.fromPointer(p);
+    return VecKeyPoint.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecKeyPointPtr>(ccore.addresses.std_VecKeyPoint_free);

--- a/packages/dartcv/lib/src/core/keypoint.dart
+++ b/packages/dartcv/lib/src/core/keypoint.dart
@@ -20,14 +20,15 @@ class KeyPoint extends CvStruct<cvg.KeyPoint> {
     }
   }
   factory KeyPoint(double x, double y, double size, double angle, double response, int octave, int classID) {
-    final ptr = calloc<cvg.KeyPoint>()
-      ..ref.x = x
-      ..ref.y = y
-      ..ref.size = size
-      ..ref.angle = angle
-      ..ref.response = response
-      ..ref.octave = octave
-      ..ref.classID = classID;
+    final ptr =
+        calloc<cvg.KeyPoint>()
+          ..ref.x = x
+          ..ref.y = y
+          ..ref.size = size
+          ..ref.angle = angle
+          ..ref.response = response
+          ..ref.octave = octave
+          ..ref.classID = classID;
     return KeyPoint._(ptr);
   }
   factory KeyPoint.fromNative(cvg.KeyPoint r) =>
@@ -69,7 +70,8 @@ class KeyPoint extends CvStruct<cvg.KeyPoint> {
   @override
   cvg.KeyPoint get ref => ptr.ref;
   @override
-  String toString() => "KeyPoint("
+  String toString() =>
+      "KeyPoint("
       "${x.toStringAsFixed(3)}, "
       "${y.toStringAsFixed(3)}, "
       "${size.toStringAsFixed(3)}, "

--- a/packages/dartcv/lib/src/core/mat.dart
+++ b/packages/dartcv/lib/src/core/mat.dart
@@ -34,9 +34,10 @@ class Mat extends CvStruct<cvg.Mat> {
     final p = calloc<cvg.Mat>();
     final (rows, cols, elemsize) = (mat.rows, mat.cols, mat.elemSize);
     cvRun(
-      () => roi == null
-          ? ccore.cv_Mat_create_11(mat.ref, rows, cols, mat.type.value, 0, 0, p, ffi.nullptr)
-          : ccore.cv_Mat_create_13(mat.ref, roi.ref, p, ffi.nullptr),
+      () =>
+          roi == null
+              ? ccore.cv_Mat_create_11(mat.ref, rows, cols, mat.type.value, 0, 0, p, ffi.nullptr)
+              : ccore.cv_Mat_create_13(mat.ref, roi.ref, p, ffi.nullptr),
     );
     final dst = Mat._(p, attach: false, externalSize: rows * cols * elemsize);
     if (copy) return dst.clone();
@@ -200,9 +201,10 @@ class Mat extends CvStruct<cvg.Mat> {
       case VecF64() when rows != null && cols != null && type != null:
       case VecF16() when rows != null && cols != null && type != null:
         cvRun(
-          () => copyData
-              ? ccore.cv_Mat_create_6(rows, cols, type.value, vec.asVoid(), p, ffi.nullptr)
-              : ccore.cv_Mat_create_6_no_copy(rows, cols, type.value, vec.asVoid(), p, ffi.nullptr),
+          () =>
+              copyData
+                  ? ccore.cv_Mat_create_6(rows, cols, type.value, vec.asVoid(), p, ffi.nullptr)
+                  : ccore.cv_Mat_create_6_no_copy(rows, cols, type.value, vec.asVoid(), p, ffi.nullptr),
         );
       default:
         throw UnsupportedError("Unsupported Vec type ${vec.runtimeType}");
@@ -377,33 +379,40 @@ class Mat extends CvStruct<cvg.Mat> {
   //!SECTION - Properties
   //SECTION - At Set
 
-  int atU8(int i0, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_get_u8_1(ref, i0)
-      : (i2 == null ? ccore.cv_Mat_get_u8_2(ref, i0, i1) : ccore.cv_Mat_get_u8_3(ref, i0, i1, i2));
+  int atU8(int i0, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_get_u8_1(ref, i0)
+          : (i2 == null ? ccore.cv_Mat_get_u8_2(ref, i0, i1) : ccore.cv_Mat_get_u8_3(ref, i0, i1, i2));
 
-  int atI8(int i0, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_get_i8_1(ref, i0)
-      : (i2 == null ? ccore.cv_Mat_get_i8_2(ref, i0, i1) : ccore.cv_Mat_get_i8_3(ref, i0, i1, i2));
+  int atI8(int i0, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_get_i8_1(ref, i0)
+          : (i2 == null ? ccore.cv_Mat_get_i8_2(ref, i0, i1) : ccore.cv_Mat_get_i8_3(ref, i0, i1, i2));
 
-  int atU16(int i0, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_get_u16_1(ref, i0)
-      : (i2 == null ? ccore.cv_Mat_get_u16_2(ref, i0, i1) : ccore.cv_Mat_get_u16_3(ref, i0, i1, i2));
+  int atU16(int i0, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_get_u16_1(ref, i0)
+          : (i2 == null ? ccore.cv_Mat_get_u16_2(ref, i0, i1) : ccore.cv_Mat_get_u16_3(ref, i0, i1, i2));
 
-  int atI16(int i0, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_get_i16_1(ref, i0)
-      : (i2 == null ? ccore.cv_Mat_get_i16_2(ref, i0, i1) : ccore.cv_Mat_get_i16_3(ref, i0, i1, i2));
+  int atI16(int i0, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_get_i16_1(ref, i0)
+          : (i2 == null ? ccore.cv_Mat_get_i16_2(ref, i0, i1) : ccore.cv_Mat_get_i16_3(ref, i0, i1, i2));
 
-  int atI32(int i0, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_get_i32_1(ref, i0)
-      : (i2 == null ? ccore.cv_Mat_get_i32_2(ref, i0, i1) : ccore.cv_Mat_get_i32_3(ref, i0, i1, i2));
+  int atI32(int i0, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_get_i32_1(ref, i0)
+          : (i2 == null ? ccore.cv_Mat_get_i32_2(ref, i0, i1) : ccore.cv_Mat_get_i32_3(ref, i0, i1, i2));
 
-  double atF32(int i0, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_get_f32_1(ref, i0)
-      : (i2 == null ? ccore.cv_Mat_get_f32_2(ref, i0, i1) : ccore.cv_Mat_get_f32_3(ref, i0, i1, i2));
+  double atF32(int i0, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_get_f32_1(ref, i0)
+          : (i2 == null ? ccore.cv_Mat_get_f32_2(ref, i0, i1) : ccore.cv_Mat_get_f32_3(ref, i0, i1, i2));
 
-  double atF64(int i0, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_get_f64_1(ref, i0)
-      : (i2 == null ? ccore.cv_Mat_get_f64_2(ref, i0, i1) : ccore.cv_Mat_get_f64_3(ref, i0, i1, i2));
+  double atF64(int i0, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_get_f64_1(ref, i0)
+          : (i2 == null ? ccore.cv_Mat_get_f64_2(ref, i0, i1) : ccore.cv_Mat_get_f64_3(ref, i0, i1, i2));
 
   /// wrapper of cv::Mat::at()
   ///
@@ -539,43 +548,54 @@ class Mat extends CvStruct<cvg.Mat> {
   //!SECTION At
 
   //SECTION - Set
-  void setU8(int i0, int val, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_set_u8_1(ref, i0, val)
-      : (i2 == null ? ccore.cv_Mat_set_u8_2(ref, i0, i1, val) : ccore.cv_Mat_set_u8_3(ref, i0, i1, i2, val));
+  void setU8(int i0, int val, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_set_u8_1(ref, i0, val)
+          : (i2 == null
+              ? ccore.cv_Mat_set_u8_2(ref, i0, i1, val)
+              : ccore.cv_Mat_set_u8_3(ref, i0, i1, i2, val));
 
-  void setI8(int i0, int val, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_set_i8_1(ref, i0, val)
-      : (i2 == null ? ccore.cv_Mat_set_i8_2(ref, i0, i1, val) : ccore.cv_Mat_set_i8_3(ref, i0, i1, i2, val));
+  void setI8(int i0, int val, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_set_i8_1(ref, i0, val)
+          : (i2 == null
+              ? ccore.cv_Mat_set_i8_2(ref, i0, i1, val)
+              : ccore.cv_Mat_set_i8_3(ref, i0, i1, i2, val));
 
-  void setU16(int i0, int val, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_set_u16_1(ref, i0, val)
-      : (i2 == null
-          ? ccore.cv_Mat_set_u16_2(ref, i0, i1, val)
-          : ccore.cv_Mat_set_u16_3(ref, i0, i1, i2, val));
+  void setU16(int i0, int val, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_set_u16_1(ref, i0, val)
+          : (i2 == null
+              ? ccore.cv_Mat_set_u16_2(ref, i0, i1, val)
+              : ccore.cv_Mat_set_u16_3(ref, i0, i1, i2, val));
 
-  void setI16(int i0, int val, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_set_i16_1(ref, i0, val)
-      : (i2 == null
-          ? ccore.cv_Mat_set_i16_2(ref, i0, i1, val)
-          : ccore.cv_Mat_set_i16_3(ref, i0, i1, i2, val));
+  void setI16(int i0, int val, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_set_i16_1(ref, i0, val)
+          : (i2 == null
+              ? ccore.cv_Mat_set_i16_2(ref, i0, i1, val)
+              : ccore.cv_Mat_set_i16_3(ref, i0, i1, i2, val));
 
-  void setI32(int i0, int val, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_set_i32_1(ref, i0, val)
-      : (i2 == null
-          ? ccore.cv_Mat_set_i32_2(ref, i0, i1, val)
-          : ccore.cv_Mat_set_i32_3(ref, i0, i1, i2, val));
+  void setI32(int i0, int val, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_set_i32_1(ref, i0, val)
+          : (i2 == null
+              ? ccore.cv_Mat_set_i32_2(ref, i0, i1, val)
+              : ccore.cv_Mat_set_i32_3(ref, i0, i1, i2, val));
 
-  void setF32(int i0, double val, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_set_f32_1(ref, i0, val)
-      : (i2 == null
-          ? ccore.cv_Mat_set_f32_2(ref, i0, i1, val)
-          : ccore.cv_Mat_set_f32_3(ref, i0, i1, i2, val));
+  void setF32(int i0, double val, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_set_f32_1(ref, i0, val)
+          : (i2 == null
+              ? ccore.cv_Mat_set_f32_2(ref, i0, i1, val)
+              : ccore.cv_Mat_set_f32_3(ref, i0, i1, i2, val));
 
-  void setF64(int i0, double val, {int? i1, int? i2}) => i1 == null
-      ? ccore.cv_Mat_set_f64_1(ref, i0, val)
-      : (i2 == null
-          ? ccore.cv_Mat_set_f64_2(ref, i0, i1, val)
-          : ccore.cv_Mat_set_f64_3(ref, i0, i1, i2, val));
+  void setF64(int i0, double val, {int? i1, int? i2}) =>
+      i1 == null
+          ? ccore.cv_Mat_set_f64_1(ref, i0, val)
+          : (i2 == null
+              ? ccore.cv_Mat_set_f64_2(ref, i0, i1, val)
+              : ccore.cv_Mat_set_f64_3(ref, i0, i1, i2, val));
 
   void setVec<T extends CvVec>(int row, int col, T val) {
     switch (val) {
@@ -844,19 +864,19 @@ class Mat extends CvStruct<cvg.Mat> {
     return switch (val) {
       Mat() => addMat(val as Mat, inplace: inplace),
       int() => switch (type.depth) {
-          MatType.CV_8U => addU8(val as int, inplace: inplace),
-          MatType.CV_8S => addI8(val as int, inplace: inplace),
-          MatType.CV_16U => addU16(val as int, inplace: inplace),
-          MatType.CV_16S => addI16(val as int, inplace: inplace),
-          MatType.CV_32S => addI32(val as int, inplace: inplace),
-          _ => throw UnsupportedError("add int to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_8U => addU8(val as int, inplace: inplace),
+        MatType.CV_8S => addI8(val as int, inplace: inplace),
+        MatType.CV_16U => addU16(val as int, inplace: inplace),
+        MatType.CV_16S => addI16(val as int, inplace: inplace),
+        MatType.CV_32S => addI32(val as int, inplace: inplace),
+        _ => throw UnsupportedError("add int to ${type.asString()} is not supported!"),
+      },
       double() => switch (type.depth) {
-          MatType.CV_32F => addF32(val as double, inplace: inplace),
-          MatType.CV_64F => addF64(val as double, inplace: inplace),
-          // MatType.CV_16F => addF16(val as double, inplace: inplace), // TODO
-          _ => throw UnsupportedError("add double to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_32F => addF32(val as double, inplace: inplace),
+        MatType.CV_64F => addF64(val as double, inplace: inplace),
+        // MatType.CV_16F => addF16(val as double, inplace: inplace), // TODO
+        _ => throw UnsupportedError("add double to ${type.asString()} is not supported!"),
+      },
       _ => throw UnsupportedError("Type $T is not supported"),
     };
   }
@@ -910,19 +930,19 @@ class Mat extends CvStruct<cvg.Mat> {
     return switch (val) {
       Mat() => subtractMat(val as Mat, inplace: inplace),
       int() => switch (type.depth) {
-          MatType.CV_8U => subtractU8(val as int, inplace: inplace),
-          MatType.CV_8S => subtractI8(val as int, inplace: inplace),
-          MatType.CV_16U => subtractU16(val as int, inplace: inplace),
-          MatType.CV_16S => subtractI16(val as int, inplace: inplace),
-          MatType.CV_32S => subtractI32(val as int, inplace: inplace),
-          _ => throw UnsupportedError("subtract int to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_8U => subtractU8(val as int, inplace: inplace),
+        MatType.CV_8S => subtractI8(val as int, inplace: inplace),
+        MatType.CV_16U => subtractU16(val as int, inplace: inplace),
+        MatType.CV_16S => subtractI16(val as int, inplace: inplace),
+        MatType.CV_32S => subtractI32(val as int, inplace: inplace),
+        _ => throw UnsupportedError("subtract int to ${type.asString()} is not supported!"),
+      },
       double() => switch (type.depth) {
-          MatType.CV_32F => subtractF32(val as double, inplace: inplace),
-          MatType.CV_64F => subtractF64(val as double, inplace: inplace),
-          // MatType.CV_16F => subtractF16(val as double, inplace: inplace), // TODO
-          _ => throw UnsupportedError("subtract double to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_32F => subtractF32(val as double, inplace: inplace),
+        MatType.CV_64F => subtractF64(val as double, inplace: inplace),
+        // MatType.CV_16F => subtractF16(val as double, inplace: inplace), // TODO
+        _ => throw UnsupportedError("subtract double to ${type.asString()} is not supported!"),
+      },
       _ => throw UnsupportedError("Type $T is not supported"),
     };
   }
@@ -977,19 +997,19 @@ class Mat extends CvStruct<cvg.Mat> {
     return switch (val) {
       Mat() => multiplyMat(val as Mat, inplace: inplace),
       int() => switch (type.depth) {
-          MatType.CV_8U => multiplyU8(val as int, inplace: inplace),
-          MatType.CV_8S => multiplyI8(val as int, inplace: inplace),
-          MatType.CV_16U => multiplyU16(val as int, inplace: inplace),
-          MatType.CV_16S => multiplyI16(val as int, inplace: inplace),
-          MatType.CV_32S => multiplyI32(val as int, inplace: inplace),
-          _ => throw UnsupportedError("multiply int to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_8U => multiplyU8(val as int, inplace: inplace),
+        MatType.CV_8S => multiplyI8(val as int, inplace: inplace),
+        MatType.CV_16U => multiplyU16(val as int, inplace: inplace),
+        MatType.CV_16S => multiplyI16(val as int, inplace: inplace),
+        MatType.CV_32S => multiplyI32(val as int, inplace: inplace),
+        _ => throw UnsupportedError("multiply int to ${type.asString()} is not supported!"),
+      },
       double() => switch (type.depth) {
-          MatType.CV_32F => multiplyF32(val as double, inplace: inplace),
-          MatType.CV_64F => multiplyF64(val as double, inplace: inplace),
-          // MatType.CV_16F => multiplyF16(val as double, inplace: inplace), // TODO
-          _ => throw UnsupportedError("multiply double to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_32F => multiplyF32(val as double, inplace: inplace),
+        MatType.CV_64F => multiplyF64(val as double, inplace: inplace),
+        // MatType.CV_16F => multiplyF16(val as double, inplace: inplace), // TODO
+        _ => throw UnsupportedError("multiply double to ${type.asString()} is not supported!"),
+      },
       _ => throw UnsupportedError("Type $T is not supported"),
     };
   }
@@ -1045,19 +1065,19 @@ class Mat extends CvStruct<cvg.Mat> {
     return switch (val) {
       Mat() => divideMat(val as Mat, inplace: inplace),
       int() => switch (type.depth) {
-          MatType.CV_8U => divideU8(val as int, inplace: inplace),
-          MatType.CV_8S => divideI8(val as int, inplace: inplace),
-          MatType.CV_16U => divideU16(val as int, inplace: inplace),
-          MatType.CV_16S => divideI16(val as int, inplace: inplace),
-          MatType.CV_32S => divideI32(val as int, inplace: inplace),
-          _ => throw UnsupportedError("divide int to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_8U => divideU8(val as int, inplace: inplace),
+        MatType.CV_8S => divideI8(val as int, inplace: inplace),
+        MatType.CV_16U => divideU16(val as int, inplace: inplace),
+        MatType.CV_16S => divideI16(val as int, inplace: inplace),
+        MatType.CV_32S => divideI32(val as int, inplace: inplace),
+        _ => throw UnsupportedError("divide int to ${type.asString()} is not supported!"),
+      },
       double() => switch (type.depth) {
-          MatType.CV_32F => divideF32(val as double, inplace: inplace),
-          MatType.CV_64F => divideF64(val as double, inplace: inplace),
-          // MatType.CV_16F => divideF16(val as double, inplace: inplace), // TODO
-          _ => throw UnsupportedError("divide double to ${type.asString()} is not supported!"),
-        },
+        MatType.CV_32F => divideF32(val as double, inplace: inplace),
+        MatType.CV_64F => divideF64(val as double, inplace: inplace),
+        // MatType.CV_16F => divideF16(val as double, inplace: inplace), // TODO
+        _ => throw UnsupportedError("divide double to ${type.asString()} is not supported!"),
+      },
       _ => throw UnsupportedError("Type $T is not supported"),
     };
   }
@@ -1217,9 +1237,10 @@ class Mat extends CvStruct<cvg.Mat> {
   /// zeros before copying the data.
   ///
   /// https://docs.opencv.org/4.x/d3/d63/classcv_1_1Mat.html#a33fd5d125b4c302b0c9aa86980791a77
-  void copyTo(Mat dst, {Mat? mask}) => mask == null
-      ? cvRun(() => ccore.cv_Mat_copyTo(ref, dst.ref, ffi.nullptr))
-      : cvRun(() => ccore.cv_Mat_copyTo_1(ref, dst.ref, mask.ref, ffi.nullptr));
+  void copyTo(Mat dst, {Mat? mask}) =>
+      mask == null
+          ? cvRun(() => ccore.cv_Mat_copyTo(ref, dst.ref, ffi.nullptr))
+          : cvRun(() => ccore.cv_Mat_copyTo_1(ref, dst.ref, mask.ref, ffi.nullptr));
 
   /// Converts an array to another data type with optional scaling.
   ///
@@ -1431,7 +1452,8 @@ class Mat extends CvStruct<cvg.Mat> {
   }
 
   @override
-  String toString() => "Mat(addr=0x${ptr.address.toRadixString(16)}, "
+  String toString() =>
+      "Mat(addr=0x${ptr.address.toRadixString(16)}, "
       "type=${type.asString()}, rows=$rows, cols=$cols, channels=$channels)";
 
   static final finalizer = OcvFinalizer<cvg.MatPtr>(ccore.addresses.cv_Mat_close);

--- a/packages/dartcv/lib/src/core/mat_async.dart
+++ b/packages/dartcv/lib/src/core/mat_async.dart
@@ -33,13 +33,12 @@ extension MatAsync on Mat {
     int g = 0,
     int b = 0,
     MatType? type,
-  }) async =>
-      Mat.fromScalar(
-        rows,
-        cols,
-        type ?? MatType.CV_8UC3,
-        Scalar(b.toDouble(), g.toDouble(), r.toDouble(), 0),
-      );
+  }) async => Mat.fromScalar(
+    rows,
+    cols,
+    type ?? MatType.CV_8UC3,
+    Scalar(b.toDouble(), g.toDouble(), r.toDouble(), 0),
+  );
 
   static Future<Mat> eyeAsync(int rows, int cols, MatType type) async {
     final p = calloc<cvg.Mat>();
@@ -71,11 +70,12 @@ extension MatAsync on Mat {
   }
 
   Future<void> copyToAsync(Mat dst, {Mat? mask}) async => cvRunAsync0(
-        (callback) => mask == null
+    (callback) =>
+        mask == null
             ? ccore.cv_Mat_copyTo(ref, dst.ref, callback)
             : ccore.cv_Mat_copyTo_1(ref, dst.ref, mask.ref, callback),
-        (c) => c.complete(),
-      );
+    (c) => c.complete(),
+  );
 
   Future<Mat> convertToAsync(MatType type, {double alpha = 1, double beta = 0}) async {
     final dst = Mat.empty();

--- a/packages/dartcv/lib/src/core/mat_async.dart
+++ b/packages/dartcv/lib/src/core/mat_async.dart
@@ -22,7 +22,7 @@ extension MatAsync on Mat {
     final p = calloc<cvg.Mat>();
     return cvRunAsync0(
       (callback) => ccore.cv_Mat_create_5(s.ref, rows, cols, type.value, p, callback),
-      (c) => c.complete(Mat.fromPointer(p)),
+      (c) => c.complete(Mat.fromPointer(p, externalSize: rows * cols * type.elemSize)),
     );
   }
 
@@ -33,18 +33,19 @@ extension MatAsync on Mat {
     int g = 0,
     int b = 0,
     MatType? type,
-  }) async => Mat.fromScalar(
-    rows,
-    cols,
-    type ?? MatType.CV_8UC3,
-    Scalar(b.toDouble(), g.toDouble(), r.toDouble(), 0),
-  );
+  }) async =>
+      Mat.fromScalar(
+        rows,
+        cols,
+        type ?? MatType.CV_8UC3,
+        Scalar(b.toDouble(), g.toDouble(), r.toDouble(), 0),
+      );
 
   static Future<Mat> eyeAsync(int rows, int cols, MatType type) async {
     final p = calloc<cvg.Mat>();
     return cvRunAsync0<Mat>(
       (callback) => ccore.cv_Mat_eye(rows, cols, type.value, p, callback),
-      (c) => c.complete(Mat.fromPointer(p)),
+      (c) => c.complete(Mat.fromPointer(p, externalSize: rows * cols * type.elemSize)),
     );
   }
 
@@ -52,7 +53,7 @@ extension MatAsync on Mat {
     final p = calloc<cvg.Mat>();
     return cvRunAsync0<Mat>(
       (callback) => ccore.cv_Mat_zeros(rows, cols, type.value, p, callback),
-      (c) => c.complete(Mat.fromPointer(p)),
+      (c) => c.complete(Mat.fromPointer(p, externalSize: rows * cols * type.elemSize)),
     );
   }
 
@@ -60,7 +61,7 @@ extension MatAsync on Mat {
     final p = calloc<cvg.Mat>();
     return cvRunAsync0<Mat>(
       (callback) => ccore.cv_Mat_ones(rows, cols, type.value, p, callback),
-      (c) => c.complete(Mat.fromPointer(p)),
+      (c) => c.complete(Mat.fromPointer(p, externalSize: rows * cols * type.elemSize)),
     );
   }
 
@@ -70,12 +71,11 @@ extension MatAsync on Mat {
   }
 
   Future<void> copyToAsync(Mat dst, {Mat? mask}) async => cvRunAsync0(
-    (callback) =>
-        mask == null
+        (callback) => mask == null
             ? ccore.cv_Mat_copyTo(ref, dst.ref, callback)
             : ccore.cv_Mat_copyTo_1(ref, dst.ref, mask.ref, callback),
-    (c) => c.complete(),
-  );
+        (c) => c.complete(),
+      );
 
   Future<Mat> convertToAsync(MatType type, {double alpha = 1, double beta = 0}) async {
     final dst = Mat.empty();

--- a/packages/dartcv/lib/src/core/mat_type.dart
+++ b/packages/dartcv/lib/src/core/mat_type.dart
@@ -13,7 +13,7 @@ import 'exception.dart';
 
 extension type const MatType(int value) implements Object {
   const MatType.makeType(int depth, int channels)
-      : value = (depth & (CV_DEPTH_MAX - 1)) | ((channels - 1) << CV_CN_SHIFT);
+    : value = (depth & (CV_DEPTH_MAX - 1)) | ((channels - 1) << CV_CN_SHIFT);
 
   const MatType.CV_8UC(int channels) : this.makeType(CV_8U, channels);
   const MatType.CV_8SC(int channels) : this.makeType(CV_8S, channels);

--- a/packages/dartcv/lib/src/core/moments.dart
+++ b/packages/dartcv/lib/src/core/moments.dart
@@ -15,7 +15,7 @@ import 'base.dart';
 class Moments extends CvStruct<cvg.Moment> {
   Moments._(ffi.Pointer<cvg.Moment> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Moment>());
     }
   }
 

--- a/packages/dartcv/lib/src/core/point.dart
+++ b/packages/dartcv/lib/src/core/point.dart
@@ -19,9 +19,10 @@ class Point extends CvStruct<cvg.CvPoint> {
     }
   }
   factory Point(int x, int y) {
-    final ptr = calloc<cvg.CvPoint>()
-      ..ref.x = x
-      ..ref.y = y;
+    final ptr =
+        calloc<cvg.CvPoint>()
+          ..ref.x = x
+          ..ref.y = y;
     return Point.fromPointer(ptr);
   }
   factory Point.fromNative(cvg.CvPoint p) => Point(p.x, p.y);
@@ -54,9 +55,10 @@ class Point2f extends CvStruct<cvg.CvPoint2f> {
     }
   }
   factory Point2f(double x, double y) {
-    final ptr = calloc<cvg.CvPoint2f>()
-      ..ref.x = x
-      ..ref.y = y;
+    final ptr =
+        calloc<cvg.CvPoint2f>()
+          ..ref.x = x
+          ..ref.y = y;
     return Point2f.fromPointer(ptr);
   }
   factory Point2f.fromNative(cvg.CvPoint2f p) => Point2f(p.x, p.y);
@@ -89,9 +91,10 @@ class Point2d extends CvStruct<cvg.CvPoint2d> {
     }
   }
   factory Point2d(double x, double y) {
-    final ptr = calloc<cvg.CvPoint2d>()
-      ..ref.x = x
-      ..ref.y = y;
+    final ptr =
+        calloc<cvg.CvPoint2d>()
+          ..ref.x = x
+          ..ref.y = y;
     return Point2d.fromPointer(ptr);
   }
   factory Point2d.fromNative(cvg.CvPoint2d p) => Point2d(p.x, p.y);
@@ -124,10 +127,11 @@ class Point3f extends CvStruct<cvg.CvPoint3f> {
     }
   }
   factory Point3f(double x, double y, double z) {
-    final ptr = calloc<cvg.CvPoint3f>()
-      ..ref.x = x
-      ..ref.y = y
-      ..ref.z = z;
+    final ptr =
+        calloc<cvg.CvPoint3f>()
+          ..ref.x = x
+          ..ref.y = y
+          ..ref.z = z;
     return Point3f.fromPointer(ptr);
   }
   factory Point3f.fromNative(cvg.CvPoint3f p) => Point3f(p.x, p.y, p.z);
@@ -163,10 +167,11 @@ class Point3i extends CvStruct<cvg.CvPoint3i> {
     }
   }
   factory Point3i(int x, int y, int z) {
-    final ptr = calloc<cvg.CvPoint3i>()
-      ..ref.x = x
-      ..ref.y = y
-      ..ref.z = z;
+    final ptr =
+        calloc<cvg.CvPoint3i>()
+          ..ref.x = x
+          ..ref.y = y
+          ..ref.z = z;
     return Point3i.fromPointer(ptr);
   }
   factory Point3i.fromNative(cvg.CvPoint3i p) => Point3i(p.x, p.y, p.z);
@@ -634,12 +639,12 @@ class VecVecPoint extends VecUnmodifible<cvg.VecVecPoint, VecPoint> {
   VecPoint operator [](int idx) => VecPoint.fromPointer(ccore.std_VecVecPoint_get_p(ptr, idx), attach: false);
 
   List<List<Point>> copyToList() => List.generate(
-        length,
-        (i) => List.generate(
-          ccore.std_VecVecPoint_length_i(ptr, i),
-          (j) => Point.fromPointer(ccore.std_VecVecPoint_get_ij(ptr, i, j)),
-        ),
-      );
+    length,
+    (i) => List.generate(
+      ccore.std_VecVecPoint_length_i(ptr, i),
+      (j) => Point.fromPointer(ccore.std_VecVecPoint_get_ij(ptr, i, j)),
+    ),
+  );
 }
 
 class VecVecPointIterator extends VecIterator<VecPoint> {
@@ -711,12 +716,12 @@ class VecVecPoint2f extends VecUnmodifible<cvg.VecVecPoint2f, VecPoint2f> {
       VecPoint2f.fromPointer(ccore.std_VecVecPoint2f_get_p(ptr, idx), attach: false);
 
   List<List<Point2f>> copyToList() => List.generate(
-        length,
-        (i) => List.generate(
-          ccore.std_VecVecPoint2f_length_i(ptr, i),
-          (j) => Point2f.fromPointer(ccore.std_VecVecPoint2f_get_ij(ptr, i, j)),
-        ),
-      );
+    length,
+    (i) => List.generate(
+      ccore.std_VecVecPoint2f_length_i(ptr, i),
+      (j) => Point2f.fromPointer(ccore.std_VecVecPoint2f_get_ij(ptr, i, j)),
+    ),
+  );
 }
 
 class VecVecPoint2fIterator extends VecIterator<VecPoint2f> {
@@ -789,12 +794,12 @@ class VecVecPoint3f extends VecUnmodifible<cvg.VecVecPoint3f, VecPoint3f> {
       VecPoint3f.fromPointer(ccore.std_VecVecPoint3f_get_p(ptr, idx), attach: false);
 
   List<List<Point3f>> copyToList() => List.generate(
-        length,
-        (i) => List.generate(
-          ccore.std_VecVecPoint3f_length_i(ptr, i),
-          (j) => Point3f.fromPointer(ccore.std_VecVecPoint3f_get_ij(ptr, i, j)),
-        ),
-      );
+    length,
+    (i) => List.generate(
+      ccore.std_VecVecPoint3f_length_i(ptr, i),
+      (j) => Point3f.fromPointer(ccore.std_VecVecPoint3f_get_ij(ptr, i, j)),
+    ),
+  );
 }
 
 class VecVecPoint3fIterator extends VecIterator<VecPoint3f> {

--- a/packages/dartcv/lib/src/core/point.dart
+++ b/packages/dartcv/lib/src/core/point.dart
@@ -15,14 +15,13 @@ import 'vec.dart';
 class Point extends CvStruct<cvg.CvPoint> {
   Point.fromPointer(ffi.Pointer<cvg.CvPoint> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvPoint>());
     }
   }
   factory Point(int x, int y) {
-    final ptr =
-        calloc<cvg.CvPoint>()
-          ..ref.x = x
-          ..ref.y = y;
+    final ptr = calloc<cvg.CvPoint>()
+      ..ref.x = x
+      ..ref.y = y;
     return Point.fromPointer(ptr);
   }
   factory Point.fromNative(cvg.CvPoint p) => Point(p.x, p.y);
@@ -51,14 +50,13 @@ class Point extends CvStruct<cvg.CvPoint> {
 class Point2f extends CvStruct<cvg.CvPoint2f> {
   Point2f.fromPointer(ffi.Pointer<cvg.CvPoint2f> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvPoint2f>());
     }
   }
   factory Point2f(double x, double y) {
-    final ptr =
-        calloc<cvg.CvPoint2f>()
-          ..ref.x = x
-          ..ref.y = y;
+    final ptr = calloc<cvg.CvPoint2f>()
+      ..ref.x = x
+      ..ref.y = y;
     return Point2f.fromPointer(ptr);
   }
   factory Point2f.fromNative(cvg.CvPoint2f p) => Point2f(p.x, p.y);
@@ -87,14 +85,13 @@ class Point2f extends CvStruct<cvg.CvPoint2f> {
 class Point2d extends CvStruct<cvg.CvPoint2d> {
   Point2d.fromPointer(ffi.Pointer<cvg.CvPoint2d> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvPoint2d>());
     }
   }
   factory Point2d(double x, double y) {
-    final ptr =
-        calloc<cvg.CvPoint2d>()
-          ..ref.x = x
-          ..ref.y = y;
+    final ptr = calloc<cvg.CvPoint2d>()
+      ..ref.x = x
+      ..ref.y = y;
     return Point2d.fromPointer(ptr);
   }
   factory Point2d.fromNative(cvg.CvPoint2d p) => Point2d(p.x, p.y);
@@ -123,15 +120,14 @@ class Point2d extends CvStruct<cvg.CvPoint2d> {
 class Point3f extends CvStruct<cvg.CvPoint3f> {
   Point3f.fromPointer(ffi.Pointer<cvg.CvPoint3f> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvPoint3f>());
     }
   }
   factory Point3f(double x, double y, double z) {
-    final ptr =
-        calloc<cvg.CvPoint3f>()
-          ..ref.x = x
-          ..ref.y = y
-          ..ref.z = z;
+    final ptr = calloc<cvg.CvPoint3f>()
+      ..ref.x = x
+      ..ref.y = y
+      ..ref.z = z;
     return Point3f.fromPointer(ptr);
   }
   factory Point3f.fromNative(cvg.CvPoint3f p) => Point3f(p.x, p.y, p.z);
@@ -163,15 +159,14 @@ class Point3f extends CvStruct<cvg.CvPoint3f> {
 class Point3i extends CvStruct<cvg.CvPoint3i> {
   Point3i.fromPointer(ffi.Pointer<cvg.CvPoint3i> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvPoint3i>());
     }
   }
   factory Point3i(int x, int y, int z) {
-    final ptr =
-        calloc<cvg.CvPoint3i>()
-          ..ref.x = x
-          ..ref.y = y
-          ..ref.z = z;
+    final ptr = calloc<cvg.CvPoint3i>()
+      ..ref.x = x
+      ..ref.y = y
+      ..ref.z = z;
     return Point3i.fromPointer(ptr);
   }
   factory Point3i.fromNative(cvg.CvPoint3i p) => Point3i(p.x, p.y, p.z);
@@ -201,9 +196,14 @@ class Point3i extends CvStruct<cvg.CvPoint3i> {
 }
 
 class VecPoint extends Vec<cvg.VecPoint, Point> {
-  VecPoint.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecPoint.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.CvPoint>(),
+      );
     }
   }
 
@@ -218,7 +218,7 @@ class VecPoint extends Vec<cvg.VecPoint, Point> {
       ccore.std_VecPoint_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecPoint.fromPointer(p);
+    return VecPoint.fromPointer(p, length: length);
   }
 
   factory VecPoint.fromMat(Mat mat) {
@@ -290,9 +290,14 @@ class VecPointIterator extends VecIterator<Point> {
 }
 
 class VecPoint2f extends Vec<cvg.VecPoint2f, Point2f> {
-  VecPoint2f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecPoint2f.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.CvPoint2f>(),
+      );
     }
   }
 
@@ -309,7 +314,7 @@ class VecPoint2f extends Vec<cvg.VecPoint2f, Point2f> {
       ccore.std_VecPoint2f_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecPoint2f.fromPointer(p);
+    return VecPoint2f.fromPointer(p, length: length);
   }
 
   factory VecPoint2f.fromMat(Mat mat) {
@@ -381,9 +386,14 @@ class VecPoint2fIterator extends VecIterator<Point2f> {
 }
 
 class VecPoint3f extends Vec<cvg.VecPoint3f, Point3f> {
-  VecPoint3f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecPoint3f.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.CvPoint3f>(),
+      );
     }
   }
 
@@ -400,7 +410,7 @@ class VecPoint3f extends Vec<cvg.VecPoint3f, Point3f> {
       ccore.std_VecPoint3f_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecPoint3f.fromPointer(p);
+    return VecPoint3f.fromPointer(p, length: length);
   }
 
   factory VecPoint3f.fromMat(Mat mat) {
@@ -472,9 +482,14 @@ class VecPoint3fIterator extends VecIterator<Point3f> {
 }
 
 class VecPoint3i extends Vec<cvg.VecPoint3i, Point3i> {
-  VecPoint3i.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecPoint3i.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.CvPoint3i>(),
+      );
     }
   }
 
@@ -491,7 +506,7 @@ class VecPoint3i extends Vec<cvg.VecPoint3i, Point3i> {
       ccore.std_VecPoint3i_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecPoint3i.fromPointer(p);
+    return VecPoint3i.fromPointer(p, length: length);
   }
 
   factory VecPoint3i.fromMat(Mat mat) {
@@ -564,9 +579,9 @@ class VecPoint3iIterator extends VecIterator<Point3i> {
 
 // VecVecPoint
 class VecVecPoint extends VecUnmodifible<cvg.VecVecPoint, VecPoint> {
-  VecVecPoint.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVecPoint.fromPointer(super.ptr, {bool attach = true, int? externalSize}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: externalSize);
     }
   }
 
@@ -579,12 +594,14 @@ class VecVecPoint extends VecUnmodifible<cvg.VecVecPoint, VecPoint> {
 
   factory VecVecPoint.generate(int length, VecPoint Function(int i) generator, {bool dispose = true}) {
     final p = ccore.std_VecVecPoint_new(length);
+    int count = 0;
     for (var i = 0; i < length; i++) {
       final v = generator(i);
+      count += v.length;
       ccore.std_VecVecPoint_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecVecPoint.fromPointer(p);
+    return VecVecPoint.fromPointer(p, externalSize: count * ffi.sizeOf<cvg.CvPoint>());
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVecPointPtr>(ccore.addresses.std_VecVecPoint_free);
@@ -614,15 +631,15 @@ class VecVecPoint extends VecUnmodifible<cvg.VecVecPoint, VecPoint> {
   ffi.Pointer<ffi.Void> asVoid() => ref.ptr.cast<ffi.Void>();
 
   @override
-  VecPoint operator [](int idx) => VecPoint.fromPointer(ccore.std_VecVecPoint_get_p(ptr, idx), false);
+  VecPoint operator [](int idx) => VecPoint.fromPointer(ccore.std_VecVecPoint_get_p(ptr, idx), attach: false);
 
   List<List<Point>> copyToList() => List.generate(
-    length,
-    (i) => List.generate(
-      ccore.std_VecVecPoint_length_i(ptr, i),
-      (j) => Point.fromPointer(ccore.std_VecVecPoint_get_ij(ptr, i, j)),
-    ),
-  );
+        length,
+        (i) => List.generate(
+          ccore.std_VecVecPoint_length_i(ptr, i),
+          (j) => Point.fromPointer(ccore.std_VecVecPoint_get_ij(ptr, i, j)),
+        ),
+      );
 }
 
 class VecVecPointIterator extends VecIterator<VecPoint> {
@@ -634,13 +651,13 @@ class VecVecPointIterator extends VecIterator<VecPoint> {
 
   /// return the reference
   @override
-  VecPoint operator [](int idx) => VecPoint.fromPointer(ccore.std_VecVecPoint_get_p(ptr, idx), false);
+  VecPoint operator [](int idx) => VecPoint.fromPointer(ccore.std_VecVecPoint_get_p(ptr, idx), attach: false);
 }
 
 class VecVecPoint2f extends VecUnmodifible<cvg.VecVecPoint2f, VecPoint2f> {
-  VecVecPoint2f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVecPoint2f.fromPointer(super.ptr, {bool attach = true, int? externalSize}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: externalSize);
     }
   }
 
@@ -653,12 +670,14 @@ class VecVecPoint2f extends VecUnmodifible<cvg.VecVecPoint2f, VecPoint2f> {
 
   factory VecVecPoint2f.generate(int length, VecPoint2f Function(int i) generator, {bool dispose = true}) {
     final p = ccore.std_VecVecPoint2f_new(length);
+    int count = 0;
     for (var i = 0; i < length; i++) {
       final v = generator(i);
+      count += v.length;
       ccore.std_VecVecPoint2f_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecVecPoint2f.fromPointer(p);
+    return VecVecPoint2f.fromPointer(p, externalSize: count * ffi.sizeOf<cvg.CvPoint2f>());
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVecPoint2fPtr>(ccore.addresses.std_VecVecPoint2f_free);
@@ -688,15 +707,16 @@ class VecVecPoint2f extends VecUnmodifible<cvg.VecVecPoint2f, VecPoint2f> {
   ffi.Pointer<ffi.Void> asVoid() => ref.ptr.cast<ffi.Void>();
 
   @override
-  VecPoint2f operator [](int idx) => VecPoint2f.fromPointer(ccore.std_VecVecPoint2f_get_p(ptr, idx), false);
+  VecPoint2f operator [](int idx) =>
+      VecPoint2f.fromPointer(ccore.std_VecVecPoint2f_get_p(ptr, idx), attach: false);
 
   List<List<Point2f>> copyToList() => List.generate(
-    length,
-    (i) => List.generate(
-      ccore.std_VecVecPoint2f_length_i(ptr, i),
-      (j) => Point2f.fromPointer(ccore.std_VecVecPoint2f_get_ij(ptr, i, j)),
-    ),
-  );
+        length,
+        (i) => List.generate(
+          ccore.std_VecVecPoint2f_length_i(ptr, i),
+          (j) => Point2f.fromPointer(ccore.std_VecVecPoint2f_get_ij(ptr, i, j)),
+        ),
+      );
 }
 
 class VecVecPoint2fIterator extends VecIterator<VecPoint2f> {
@@ -708,13 +728,14 @@ class VecVecPoint2fIterator extends VecIterator<VecPoint2f> {
 
   /// return the reference
   @override
-  VecPoint2f operator [](int idx) => VecPoint2f.fromPointer(ccore.std_VecVecPoint2f_get_p(ptr, idx), false);
+  VecPoint2f operator [](int idx) =>
+      VecPoint2f.fromPointer(ccore.std_VecVecPoint2f_get_p(ptr, idx), attach: false);
 }
 
 class VecVecPoint3f extends VecUnmodifible<cvg.VecVecPoint3f, VecPoint3f> {
-  VecVecPoint3f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVecPoint3f.fromPointer(super.ptr, {bool attach = true, int? externalSize}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: externalSize);
     }
   }
 
@@ -727,12 +748,14 @@ class VecVecPoint3f extends VecUnmodifible<cvg.VecVecPoint3f, VecPoint3f> {
 
   factory VecVecPoint3f.generate(int length, VecPoint3f Function(int i) generator, {bool dispose = true}) {
     final p = ccore.std_VecVecPoint3f_new(length);
+    int count = 0;
     for (var i = 0; i < length; i++) {
       final v = generator(i);
+      count += v.length;
       ccore.std_VecVecPoint3f_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecVecPoint3f.fromPointer(p);
+    return VecVecPoint3f.fromPointer(p, externalSize: count * ffi.sizeOf<cvg.CvPoint3f>());
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVecPoint3fPtr>(ccore.addresses.std_VecVecPoint3f_free);
@@ -762,15 +785,16 @@ class VecVecPoint3f extends VecUnmodifible<cvg.VecVecPoint3f, VecPoint3f> {
   ffi.Pointer<ffi.Void> asVoid() => ref.ptr.cast<ffi.Void>();
 
   @override
-  VecPoint3f operator [](int idx) => VecPoint3f.fromPointer(ccore.std_VecVecPoint3f_get_p(ptr, idx), false);
+  VecPoint3f operator [](int idx) =>
+      VecPoint3f.fromPointer(ccore.std_VecVecPoint3f_get_p(ptr, idx), attach: false);
 
   List<List<Point3f>> copyToList() => List.generate(
-    length,
-    (i) => List.generate(
-      ccore.std_VecVecPoint3f_length_i(ptr, i),
-      (j) => Point3f.fromPointer(ccore.std_VecVecPoint3f_get_ij(ptr, i, j)),
-    ),
-  );
+        length,
+        (i) => List.generate(
+          ccore.std_VecVecPoint3f_length_i(ptr, i),
+          (j) => Point3f.fromPointer(ccore.std_VecVecPoint3f_get_ij(ptr, i, j)),
+        ),
+      );
 }
 
 class VecVecPoint3fIterator extends VecIterator<VecPoint3f> {
@@ -782,7 +806,8 @@ class VecVecPoint3fIterator extends VecIterator<VecPoint3f> {
 
   /// return the reference
   @override
-  VecPoint3f operator [](int idx) => VecPoint3f.fromPointer(ccore.std_VecVecPoint3f_get_p(ptr, idx), false);
+  VecPoint3f operator [](int idx) =>
+      VecPoint3f.fromPointer(ccore.std_VecVecPoint3f_get_p(ptr, idx), attach: false);
 }
 
 extension ListPointExtension on List<Point> {
@@ -811,8 +836,6 @@ extension ListListPointExtension on List<List<Point>> {
 }
 
 extension VecPointExtension on VecPoint {
-  @Deprecated("use asVecVec() instead")
-  VecVecPoint get toVecVecPoint => VecVecPoint.fromVecPoint(this);
   VecVecPoint asVecVec() => VecVecPoint.fromVecPoint(this);
 }
 
@@ -827,19 +850,13 @@ extension ListListPoint3fExtension on List<List<Point3f>> {
 }
 
 extension PointRecordExtension on (int x, int y) {
-  @Deprecated("use toPoint() instead")
-  Point get asPoint => Point(this.$1, this.$2);
   Point toPoint() => Point(this.$1, this.$2);
 }
 
 extension Point2fRecordExtension on (double x, double y) {
-  @Deprecated("use toPoint2f() instead")
-  Point2f get asPoint2f => Point2f(this.$1, this.$2);
   Point2f toPoint2f() => Point2f(this.$1, this.$2);
 }
 
 extension Point3fRecordExtension on (double x, double y, double z) {
-  @Deprecated("use toPoint3f() instead")
-  Point3f get asPoint3f => Point3f(this.$1, this.$2, this.$3);
   Point3f toPoint3f() => Point3f(this.$1, this.$2, this.$3);
 }

--- a/packages/dartcv/lib/src/core/rect.dart
+++ b/packages/dartcv/lib/src/core/rect.dart
@@ -20,11 +20,12 @@ class Rect extends CvStruct<cvg.CvRect> {
     }
   }
   factory Rect(int x, int y, int width, int height) {
-    final ptr = calloc<cvg.CvRect>()
-      ..ref.x = x
-      ..ref.y = y
-      ..ref.width = width
-      ..ref.height = height;
+    final ptr =
+        calloc<cvg.CvRect>()
+          ..ref.x = x
+          ..ref.y = y
+          ..ref.width = width
+          ..ref.height = height;
     return Rect._(ptr);
   }
   factory Rect.fromNative(cvg.CvRect p) => Rect(p.x, p.y, p.width, p.height);
@@ -67,11 +68,12 @@ class Rect2f extends CvStruct<cvg.CvRect2f> {
     }
   }
   factory Rect2f(double x, double y, double width, double height) {
-    final ptr = calloc<cvg.CvRect2f>()
-      ..ref.x = x
-      ..ref.y = y
-      ..ref.width = width
-      ..ref.height = height;
+    final ptr =
+        calloc<cvg.CvRect2f>()
+          ..ref.x = x
+          ..ref.y = y
+          ..ref.width = width
+          ..ref.height = height;
     return Rect2f._(ptr);
   }
   factory Rect2f.fromNative(cvg.CvRect2f p) => Rect2f(p.x, p.y, p.width, p.height);
@@ -115,13 +117,15 @@ class RotatedRect extends CvStruct<cvg.RotatedRect> {
     }
   }
   factory RotatedRect(Point2f center, (double, double) size, double angle) {
-    final sz = calloc<cvg.CvSize2f>()
-      ..ref.width = size.$1
-      ..ref.height = size.$2;
-    final ptr = calloc<cvg.RotatedRect>()
-      ..ref.center = center.ref
-      ..ref.size = sz.ref
-      ..ref.angle = angle;
+    final sz =
+        calloc<cvg.CvSize2f>()
+          ..ref.width = size.$1
+          ..ref.height = size.$2;
+    final ptr =
+        calloc<cvg.RotatedRect>()
+          ..ref.center = center.ref
+          ..ref.size = sz.ref
+          ..ref.angle = angle;
     final rect = RotatedRect._(ptr);
     calloc.free(sz);
     return rect;

--- a/packages/dartcv/lib/src/core/rect.dart
+++ b/packages/dartcv/lib/src/core/rect.dart
@@ -16,16 +16,15 @@ import 'vec.dart';
 class Rect extends CvStruct<cvg.CvRect> {
   Rect._(ffi.Pointer<cvg.CvRect> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvRect>());
     }
   }
   factory Rect(int x, int y, int width, int height) {
-    final ptr =
-        calloc<cvg.CvRect>()
-          ..ref.x = x
-          ..ref.y = y
-          ..ref.width = width
-          ..ref.height = height;
+    final ptr = calloc<cvg.CvRect>()
+      ..ref.x = x
+      ..ref.y = y
+      ..ref.width = width
+      ..ref.height = height;
     return Rect._(ptr);
   }
   factory Rect.fromNative(cvg.CvRect p) => Rect(p.x, p.y, p.width, p.height);
@@ -64,16 +63,15 @@ class Rect extends CvStruct<cvg.CvRect> {
 class Rect2f extends CvStruct<cvg.CvRect2f> {
   Rect2f._(ffi.Pointer<cvg.CvRect2f> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvRect2f>());
     }
   }
   factory Rect2f(double x, double y, double width, double height) {
-    final ptr =
-        calloc<cvg.CvRect2f>()
-          ..ref.x = x
-          ..ref.y = y
-          ..ref.width = width
-          ..ref.height = height;
+    final ptr = calloc<cvg.CvRect2f>()
+      ..ref.x = x
+      ..ref.y = y
+      ..ref.width = width
+      ..ref.height = height;
     return Rect2f._(ptr);
   }
   factory Rect2f.fromNative(cvg.CvRect2f p) => Rect2f(p.x, p.y, p.width, p.height);
@@ -113,19 +111,17 @@ class Rect2f extends CvStruct<cvg.CvRect2f> {
 class RotatedRect extends CvStruct<cvg.RotatedRect> {
   RotatedRect._(ffi.Pointer<cvg.RotatedRect> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.RotatedRect>());
     }
   }
   factory RotatedRect(Point2f center, (double, double) size, double angle) {
-    final sz =
-        calloc<cvg.CvSize2f>()
-          ..ref.width = size.$1
-          ..ref.height = size.$2;
-    final ptr =
-        calloc<cvg.RotatedRect>()
-          ..ref.center = center.ref
-          ..ref.size = sz.ref
-          ..ref.angle = angle;
+    final sz = calloc<cvg.CvSize2f>()
+      ..ref.width = size.$1
+      ..ref.height = size.$2;
+    final ptr = calloc<cvg.RotatedRect>()
+      ..ref.center = center.ref
+      ..ref.size = sz.ref
+      ..ref.angle = angle;
     final rect = RotatedRect._(ptr);
     calloc.free(sz);
     return rect;
@@ -178,9 +174,14 @@ class RotatedRect extends CvStruct<cvg.RotatedRect> {
 }
 
 class VecRect extends Vec<cvg.VecRect, Rect> {
-  VecRect.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecRect.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.CvRect>(),
+      );
     }
   }
 
@@ -196,7 +197,7 @@ class VecRect extends Vec<cvg.VecRect, Rect> {
       ccore.std_VecRect_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecRect.fromPointer(p);
+    return VecRect.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecRectPtr>(ccore.addresses.std_VecRect_free);
@@ -262,9 +263,14 @@ class VecRectIterator extends VecIterator<Rect> {
 }
 
 class VecRect2f extends Vec<cvg.VecRect2f, Rect2f> {
-  VecRect2f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecRect2f.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<cvg.CvRect2f>(),
+      );
     }
   }
 
@@ -281,7 +287,7 @@ class VecRect2f extends Vec<cvg.VecRect2f, Rect2f> {
       ccore.std_VecRect2f_set(p, i, v.ref);
       if (dispose) v.dispose();
     }
-    return VecRect2f.fromPointer(p);
+    return VecRect2f.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecRect2fPtr>(ccore.addresses.std_VecRect2f_free);

--- a/packages/dartcv/lib/src/core/scalar.dart
+++ b/packages/dartcv/lib/src/core/scalar.dart
@@ -13,17 +13,16 @@ import 'base.dart';
 class Scalar extends CvStruct<cvg.Scalar> {
   Scalar._(ffi.Pointer<cvg.Scalar> ptr, [bool attach = true]) : super.fromPointer(ptr) {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.Scalar>());
     }
   }
 
   factory Scalar([double val1 = 0.0, double val2 = 0.0, double val3 = 0.0, double val4 = 0.0]) {
-    final p =
-        calloc<cvg.Scalar>()
-          ..ref.val1 = val1
-          ..ref.val2 = val2
-          ..ref.val3 = val3
-          ..ref.val4 = val4;
+    final p = calloc<cvg.Scalar>()
+      ..ref.val1 = val1
+      ..ref.val2 = val2
+      ..ref.val3 = val3
+      ..ref.val4 = val4;
     return Scalar._(p);
   }
   factory Scalar.fromNative(cvg.Scalar s) => Scalar(s.val1, s.val2, s.val3, s.val4);

--- a/packages/dartcv/lib/src/core/scalar.dart
+++ b/packages/dartcv/lib/src/core/scalar.dart
@@ -18,11 +18,12 @@ class Scalar extends CvStruct<cvg.Scalar> {
   }
 
   factory Scalar([double val1 = 0.0, double val2 = 0.0, double val3 = 0.0, double val4 = 0.0]) {
-    final p = calloc<cvg.Scalar>()
-      ..ref.val1 = val1
-      ..ref.val2 = val2
-      ..ref.val3 = val3
-      ..ref.val4 = val4;
+    final p =
+        calloc<cvg.Scalar>()
+          ..ref.val1 = val1
+          ..ref.val2 = val2
+          ..ref.val3 = val3
+          ..ref.val4 = val4;
     return Scalar._(p);
   }
   factory Scalar.fromNative(cvg.Scalar s) => Scalar(s.val1, s.val2, s.val3, s.val4);

--- a/packages/dartcv/lib/src/core/size.dart
+++ b/packages/dartcv/lib/src/core/size.dart
@@ -12,25 +12,23 @@ import 'base.dart';
 class Size extends CvStruct<cvg.CvSize> {
   Size.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvSize>());
     }
   }
 
   factory Size(int width, int height) {
-    final p =
-        calloc<cvg.CvSize>()
-          ..ref.height = height
-          ..ref.width = width;
+    final p = calloc<cvg.CvSize>()
+      ..ref.height = height
+      ..ref.width = width;
     return Size.fromPointer(p);
   }
 
   factory Size.fromNative(cvg.CvSize sz) => Size(sz.width, sz.height);
 
   factory Size.fromRecord((int, int) record) {
-    final p =
-        calloc<cvg.CvSize>()
-          ..ref.height = record.$2
-          ..ref.width = record.$1;
+    final p = calloc<cvg.CvSize>()
+      ..ref.height = record.$2
+      ..ref.width = record.$1;
     return Size.fromPointer(p);
   }
 
@@ -62,33 +60,30 @@ class Size extends CvStruct<cvg.CvSize> {
 class Size2f extends CvStruct<cvg.CvSize2f> {
   Size2f.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.CvSize2f>());
     }
   }
 
   factory Size2f(double width, double height) {
-    final p =
-        calloc<cvg.CvSize2f>()
-          ..ref.height = height
-          ..ref.width = width;
+    final p = calloc<cvg.CvSize2f>()
+      ..ref.height = height
+      ..ref.width = width;
     return Size2f.fromPointer(p);
   }
 
   factory Size2f.fromNative(cvg.CvSize2f sz) => Size2f(sz.width, sz.height);
 
   factory Size2f.fromRecord((double, double) record) {
-    final p =
-        calloc<cvg.CvSize2f>()
-          ..ref.height = record.$2
-          ..ref.width = record.$1;
+    final p = calloc<cvg.CvSize2f>()
+      ..ref.height = record.$2
+      ..ref.width = record.$1;
     return Size2f.fromPointer(p);
   }
 
   factory Size2f.fromSize(Size size) {
-    final p =
-        calloc<cvg.CvSize2f>()
-          ..ref.height = size.height.toDouble()
-          ..ref.width = size.width.toDouble();
+    final p = calloc<cvg.CvSize2f>()
+      ..ref.height = size.height.toDouble()
+      ..ref.width = size.width.toDouble();
     return Size2f.fromPointer(p);
   }
 

--- a/packages/dartcv/lib/src/core/size.dart
+++ b/packages/dartcv/lib/src/core/size.dart
@@ -17,18 +17,20 @@ class Size extends CvStruct<cvg.CvSize> {
   }
 
   factory Size(int width, int height) {
-    final p = calloc<cvg.CvSize>()
-      ..ref.height = height
-      ..ref.width = width;
+    final p =
+        calloc<cvg.CvSize>()
+          ..ref.height = height
+          ..ref.width = width;
     return Size.fromPointer(p);
   }
 
   factory Size.fromNative(cvg.CvSize sz) => Size(sz.width, sz.height);
 
   factory Size.fromRecord((int, int) record) {
-    final p = calloc<cvg.CvSize>()
-      ..ref.height = record.$2
-      ..ref.width = record.$1;
+    final p =
+        calloc<cvg.CvSize>()
+          ..ref.height = record.$2
+          ..ref.width = record.$1;
     return Size.fromPointer(p);
   }
 
@@ -65,25 +67,28 @@ class Size2f extends CvStruct<cvg.CvSize2f> {
   }
 
   factory Size2f(double width, double height) {
-    final p = calloc<cvg.CvSize2f>()
-      ..ref.height = height
-      ..ref.width = width;
+    final p =
+        calloc<cvg.CvSize2f>()
+          ..ref.height = height
+          ..ref.width = width;
     return Size2f.fromPointer(p);
   }
 
   factory Size2f.fromNative(cvg.CvSize2f sz) => Size2f(sz.width, sz.height);
 
   factory Size2f.fromRecord((double, double) record) {
-    final p = calloc<cvg.CvSize2f>()
-      ..ref.height = record.$2
-      ..ref.width = record.$1;
+    final p =
+        calloc<cvg.CvSize2f>()
+          ..ref.height = record.$2
+          ..ref.width = record.$1;
     return Size2f.fromPointer(p);
   }
 
   factory Size2f.fromSize(Size size) {
-    final p = calloc<cvg.CvSize2f>()
-      ..ref.height = size.height.toDouble()
-      ..ref.width = size.width.toDouble();
+    final p =
+        calloc<cvg.CvSize2f>()
+          ..ref.height = size.height.toDouble()
+          ..ref.width = size.width.toDouble();
     return Size2f.fromPointer(p);
   }
 

--- a/packages/dartcv/lib/src/core/termcriteria.dart
+++ b/packages/dartcv/lib/src/core/termcriteria.dart
@@ -23,10 +23,11 @@ class TermCriteria extends CvStruct<cvg.TermCriteria> {
   }
 
   factory TermCriteria(int type, int cound, double eps) {
-    final p = calloc<cvg.TermCriteria>()
-      ..ref.type = type
-      ..ref.maxCount = cound
-      ..ref.epsilon = eps;
+    final p =
+        calloc<cvg.TermCriteria>()
+          ..ref.type = type
+          ..ref.maxCount = cound
+          ..ref.epsilon = eps;
     return TermCriteria.fromPointer(p);
   }
 

--- a/packages/dartcv/lib/src/core/termcriteria.dart
+++ b/packages/dartcv/lib/src/core/termcriteria.dart
@@ -18,16 +18,15 @@ import 'base.dart';
 class TermCriteria extends CvStruct<cvg.TermCriteria> {
   TermCriteria.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast(), detach: this);
+      finalizer.attach(this, ptr.cast(), detach: this, externalSize: ffi.sizeOf<cvg.TermCriteria>());
     }
   }
 
   factory TermCriteria(int type, int cound, double eps) {
-    final p =
-        calloc<cvg.TermCriteria>()
-          ..ref.type = type
-          ..ref.maxCount = cound
-          ..ref.epsilon = eps;
+    final p = calloc<cvg.TermCriteria>()
+      ..ref.type = type
+      ..ref.maxCount = cound
+      ..ref.epsilon = eps;
     return TermCriteria.fromPointer(p);
   }
 

--- a/packages/dartcv/lib/src/core/vec.dart
+++ b/packages/dartcv/lib/src/core/vec.dart
@@ -94,21 +94,26 @@ abstract class VecUnmodifible<N extends ffi.Struct, T> extends Vec<N, T> {
 }
 
 class VecUChar extends Vec<cvg.VecUChar, int> {
-  VecUChar.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecUChar.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.UnsignedChar>(),
+      );
     }
   }
 
   factory VecUChar([int length = 0, int value = 0]) =>
-      VecUChar.fromPointer(ccore.std_VecUChar_new_1(length, value));
+      VecUChar.fromPointer(ccore.std_VecUChar_new_1(length, value), length: length);
 
   factory VecUChar.fromList(List<int> pts) {
     final length = pts.length;
     final p = ccore.std_VecUChar_new(length);
     final pdata = ccore.std_VecUChar_data(p);
     pdata.cast<U8>().asTypedList(length).setAll(0, pts);
-    return VecUChar.fromPointer(p);
+    return VecUChar.fromPointer(p, length: pts.length);
   }
 
   factory VecUChar.generate(int length, int Function(int i) generator) {
@@ -116,7 +121,7 @@ class VecUChar extends Vec<cvg.VecUChar, int> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecUChar_set(p, i, generator(i));
     }
-    return VecUChar.fromPointer(p);
+    return VecUChar.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecUCharPtr>(ccore.addresses.std_VecUChar_free);
@@ -195,20 +200,25 @@ class VecUCharIterator extends VecIterator<int> {
 }
 
 class VecChar extends Vec<cvg.VecChar, int> {
-  VecChar.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecChar.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.Char>(),
+      );
     }
   }
 
   factory VecChar([int length = 0, int value = 0]) =>
-      VecChar.fromPointer(ccore.std_VecChar_new_1(length, value));
+      VecChar.fromPointer(ccore.std_VecChar_new_1(length, value), length: length);
   factory VecChar.fromList(List<int> pts) {
     final length = pts.length;
     final p = ccore.std_VecChar_new(length);
     final pdata = ccore.std_VecChar_data(p);
     pdata.cast<I8>().asTypedList(length).setAll(0, pts);
-    return VecChar.fromPointer(p);
+    return VecChar.fromPointer(p, length: pts.length);
   }
 
   factory VecChar.generate(int length, int Function(int i) generator) {
@@ -216,7 +226,7 @@ class VecChar extends Vec<cvg.VecChar, int> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecChar_set(p, i, generator(i));
     }
-    return VecChar.fromPointer(p);
+    return VecChar.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecCharPtr>(ccore.addresses.std_VecChar_free);
@@ -289,9 +299,9 @@ class VecCharIterator extends VecIterator<int> {
 }
 
 class VecVecChar extends VecUnmodifible<cvg.VecVecChar, VecChar> {
-  VecVecChar.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecVecChar.fromPointer(super.ptr, {bool attach = true, int? externalSize}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this, externalSize: externalSize);
     }
   }
 
@@ -301,14 +311,16 @@ class VecVecChar extends VecUnmodifible<cvg.VecVecChar, VecChar> {
 
   factory VecVecChar.generate(int length, Iterable<int> Function(int i) generator) {
     final p = ccore.std_VecVecChar_new(length);
+    int count = 0;
     for (var i = 0; i < length; i++) {
       final pts = generator(i);
+      count += pts.length;
       final pp = ccore.std_VecChar_new(pts.length);
       final ppData = ccore.std_VecChar_data(pp);
       ppData.cast<I8>().asTypedList(pts.length).setAll(0, pts);
       ccore.std_VecVecChar_set(p, i, pp);
     }
-    return VecVecChar.fromPointer(p);
+    return VecVecChar.fromPointer(p, externalSize: count * ffi.sizeOf<ffi.Char>());
   }
 
   static final finalizer = OcvFinalizer<cvg.VecVecCharPtr>(ccore.addresses.std_VecVecChar_free);
@@ -338,7 +350,7 @@ class VecVecChar extends VecUnmodifible<cvg.VecVecChar, VecChar> {
   ffi.Pointer<ffi.Void> asVoid() => throw UnsupportedError('Not supported');
 
   @override
-  VecChar operator [](int idx) => VecChar.fromPointer(ccore.std_VecVecChar_get(ptr, idx), false);
+  VecChar operator [](int idx) => VecChar.fromPointer(ccore.std_VecVecChar_get(ptr, idx), attach: false);
 
   @override
   int size() => ccore.std_VecVecChar_length(ptr);
@@ -353,25 +365,30 @@ class VecVecCharIterator extends VecIterator<VecChar> {
 
   /// return the reference
   @override
-  VecChar operator [](int idx) => VecChar.fromPointer(ccore.std_VecVecChar_get(ptr, idx), false);
+  VecChar operator [](int idx) => VecChar.fromPointer(ccore.std_VecVecChar_get(ptr, idx), attach: false);
 }
 
 class VecU16 extends Vec<cvg.VecU16, int> {
-  VecU16.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecU16.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.Uint16>(),
+      );
     }
   }
 
   factory VecU16([int length = 0, int value = 0]) =>
-      VecU16.fromPointer(ccore.std_VecU16_new_1(length, value));
+      VecU16.fromPointer(ccore.std_VecU16_new_1(length, value), length: length);
 
   factory VecU16.fromList(List<int> pts) {
     final length = pts.length;
     final p = ccore.std_VecU16_new(length);
     final pdata = ccore.std_VecU16_data(p);
     pdata.asTypedList(length).setAll(0, pts);
-    return VecU16.fromPointer(p);
+    return VecU16.fromPointer(p, length: pts.length);
   }
 
   factory VecU16.generate(int length, int Function(int i) generator) {
@@ -379,7 +396,7 @@ class VecU16 extends Vec<cvg.VecU16, int> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecU16_set(p, i, generator(i));
     }
-    return VecU16.fromPointer(p);
+    return VecU16.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecU16Ptr>(ccore.addresses.std_VecU16_free);
@@ -448,21 +465,26 @@ class VecU16Iterator extends VecIterator<int> {
 }
 
 class VecI16 extends Vec<cvg.VecI16, int> {
-  VecI16.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecI16.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.Int16>(),
+      );
     }
   }
 
   factory VecI16([int length = 0, int value = 0]) =>
-      VecI16.fromPointer(ccore.std_VecI16_new_1(length, value));
+      VecI16.fromPointer(ccore.std_VecI16_new_1(length, value), length: length);
 
   factory VecI16.fromList(List<int> pts) {
     final length = pts.length;
     final p = ccore.std_VecI16_new(length);
     final pdata = ccore.std_VecI16_data(p);
     pdata.asTypedList(length).setAll(0, pts);
-    return VecI16.fromPointer(p);
+    return VecI16.fromPointer(p, length: pts.length);
   }
 
   factory VecI16.generate(int length, int Function(int i) generator) {
@@ -470,7 +492,7 @@ class VecI16 extends Vec<cvg.VecI16, int> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecI16_set(p, i, generator(i));
     }
-    return VecI16.fromPointer(p);
+    return VecI16.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecI16Ptr>(ccore.addresses.std_VecI16_free);
@@ -538,21 +560,26 @@ class VecI16Iterator extends VecIterator<int> {
 }
 
 class VecI32 extends Vec<cvg.VecI32, int> {
-  VecI32.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecI32.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.Int32>(),
+      );
     }
   }
 
   factory VecI32([int length = 0, int value = 0]) =>
-      VecI32.fromPointer(ccore.std_VecI32_new_1(length, value));
+      VecI32.fromPointer(ccore.std_VecI32_new_1(length, value), length: length);
 
   factory VecI32.fromList(List<int> pts) {
     final length = pts.length;
     final p = ccore.std_VecI32_new(length);
     final pdata = ccore.std_VecI32_data(p);
     pdata.asTypedList(length).setAll(0, pts);
-    return VecI32.fromPointer(p);
+    return VecI32.fromPointer(p, length: pts.length);
   }
 
   factory VecI32.generate(int length, int Function(int i) generator) {
@@ -560,7 +587,7 @@ class VecI32 extends Vec<cvg.VecI32, int> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecI32_set(p, i, generator(i));
     }
-    return VecI32.fromPointer(p);
+    return VecI32.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecI32Ptr>(ccore.addresses.std_VecI32_free);
@@ -630,20 +657,25 @@ class VecI32Iterator extends VecIterator<int> {
 }
 
 class VecF32 extends Vec<cvg.VecF32, double> {
-  VecF32.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecF32.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.Float>(),
+      );
     }
   }
 
   factory VecF32([int length = 0, double value = 0.0]) =>
-      VecF32.fromPointer(ccore.std_VecF32_new_1(length, value));
+      VecF32.fromPointer(ccore.std_VecF32_new_1(length, value), length: length);
   factory VecF32.fromList(List<double> pts) {
     final length = pts.length;
     final p = ccore.std_VecF32_new(length);
     final pdata = ccore.std_VecF32_data(p);
     pdata.asTypedList(length).setAll(0, pts);
-    return VecF32.fromPointer(p);
+    return VecF32.fromPointer(p, length: pts.length);
   }
 
   factory VecF32.generate(int length, double Function(int i) generator) {
@@ -651,7 +683,7 @@ class VecF32 extends Vec<cvg.VecF32, double> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecF32_set(p, i, generator(i));
     }
-    return VecF32.fromPointer(p);
+    return VecF32.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecF32Ptr>(ccore.addresses.std_VecF32_free);
@@ -719,20 +751,25 @@ class VecF32Iterator extends VecIterator<double> {
 }
 
 class VecF64 extends Vec<cvg.VecF64, double> {
-  VecF64.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecF64.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.Double>(),
+      );
     }
   }
 
   factory VecF64([int length = 0, double value = 0.0]) =>
-      VecF64.fromPointer(ccore.std_VecF64_new_1(length, value));
+      VecF64.fromPointer(ccore.std_VecF64_new_1(length, value), length: length);
   factory VecF64.fromList(List<double> pts) {
     final length = pts.length;
     final p = ccore.std_VecF64_new(length);
     final pdata = ccore.std_VecF64_data(p);
     pdata.asTypedList(length).setAll(0, pts);
-    return VecF64.fromPointer(p);
+    return VecF64.fromPointer(p, length: pts.length);
   }
 
   factory VecF64.generate(int length, double Function(int i) generator) {
@@ -740,7 +777,7 @@ class VecF64 extends Vec<cvg.VecF64, double> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecF64_set(p, i, generator(i));
     }
-    return VecF64.fromPointer(p);
+    return VecF64.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecF64Ptr>(ccore.addresses.std_VecF64_free);
@@ -810,9 +847,14 @@ class VecF64Iterator extends VecIterator<double> {
 }
 
 class VecF16 extends Vec<cvg.VecF16, double> {
-  VecF16.fromPointer(super.ptr, [bool attach = true]) : super.fromPointer() {
+  VecF16.fromPointer(super.ptr, {bool attach = true, int? length}) : super.fromPointer() {
     if (attach) {
-      finalizer.attach(this, ptr.cast<ffi.Void>(), detach: this);
+      finalizer.attach(
+        this,
+        ptr.cast<ffi.Void>(),
+        detach: this,
+        externalSize: length == null ? null : length * ffi.sizeOf<ffi.Uint16>(),
+      );
     }
   }
 
@@ -826,7 +868,7 @@ class VecF16 extends Vec<cvg.VecF16, double> {
     for (var i = 0; i < length; i++) {
       ccore.std_VecF16_set(p, i, generator(i).fp16);
     }
-    return VecF16.fromPointer(p);
+    return VecF16.fromPointer(p, length: length);
   }
 
   static final finalizer = OcvFinalizer<cvg.VecF16Ptr>(ccore.addresses.std_VecF16_free);
@@ -914,9 +956,12 @@ extension StringVecExtension on String {
   }
 
   VecChar get i8 {
-    final p = toNativeUtf8();
-    final v = VecChar.fromList(p.cast<ffi.Int8>().asTypedList(p.length));
-    return v;
+    return cvRunArena<VecChar>((arena) {
+      final p = toNativeUtf8(allocator: arena);
+      final pp = p.cast<ffi.Char>();
+      final v = VecChar.fromList(List.generate(p.length, (idx) => pp[idx]));
+      return v;
+    });
   }
 }
 


### PR DESCRIPTION
fix: #341 

Only supports primitive struct types like `Rect` and `Mat`, measuring the occupied bytes of other opaque types like `Net` is hard. 