### PR TITLE
[opencv_core] & [opencv_dart] with android auto ignore unuse abi

### DIFF
--- a/packages/opencv_core/android/build.gradle
+++ b/packages/opencv_core/android/build.gradle
@@ -1,7 +1,7 @@
 // The Android Gradle Plugin builds the native code with the Android NDK.
 
-group = "dev.rainyl.opencv_core"
-version = "1.0"
+group = 'dev.rainyl.opencv_core'
+version = '1.0'
 
 buildscript {
     repositories {
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // The Android Gradle Plugin knows how to build native code with the NDK.
-        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath('com.android.tools.build:gradle:8.1.0')
     }
 }
 
@@ -22,13 +22,13 @@ rootProject.allprojects {
     }
 }
 
-apply plugin: "com.android.library"
+apply plugin: 'com.android.library'
 
 def SOURCE_DIR = project.buildscript.sourceFile.parentFile
 
 android {
-    if (project.android.hasProperty("namespace")) {
-        namespace = "dev.rainyl.opencv_core"
+    if (project.android.hasProperty('namespace')) {
+        namespace = 'dev.rainyl.opencv_core'
     }
 
     // Bumping the plugin compileSdk version requires all clients of this plugin
@@ -44,15 +44,15 @@ android {
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {
         cmake {
-            path = "../src/CMakeLists.txt"
+      path = '../src/CMakeLists.txt'
 
-            // The default CMake version for the Android Gradle Plugin is 3.10.2.
-            // https://developer.android.com/studio/projects/install-ndk#vanilla_cmake
-            //
-            // The Flutter tooling requires that developers have CMake 3.10 or later
-            // installed. You should not increase this version, as doing so will cause
-            // the plugin to fail to compile for some customers of the plugin.
-            // version "3.10.2"
+        // The default CMake version for the Android Gradle Plugin is 3.10.2.
+        // https://developer.android.com/studio/projects/install-ndk#vanilla_cmake
+        //
+        // The Flutter tooling requires that developers have CMake 3.10 or later
+        // installed. You should not increase this version, as doing so will cause
+        // the plugin to fail to compile for some customers of the plugin.
+        // version "3.10.2"
         }
     }
 
@@ -67,8 +67,8 @@ android {
       // Invoke the shared CMake build with the Android Gradle Plugin.
       externalNativeBuild {
           cmake {
-              arguments "-DANDROID_ARM_NEON=TRUE",
-                "-DANDROID_STL=c++_static",
+        arguments '-DANDROID_ARM_NEON=TRUE',
+                '-DANDROID_STL=c++_static',
                 "-DCMAKE_INSTALL_PREFIX=$SOURCE_DIR/src/main/jniLibs"
           }
       }
@@ -77,7 +77,36 @@ android {
         release {
           externalNativeBuild {
             cmake {
-              arguments "-DCMAKE_BUILD_TYPE=Release"
+              arguments '-DCMAKE_BUILD_TYPE=Release'
+            }
+          }
+
+          def targetPlatforms = project.getProperty('target-platform').split(',') as List
+          if (!targetPlatforms.isEmpty()) {
+            // ignore not use abi
+            def excludeList = ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
+
+            targetPlatforms.each { platform ->
+              if (platform.equals('android-arm64')) {
+                excludeList.remove('arm64-v8a')
+              }
+              if (platform.equals('android-arm')) {
+                excludeList.remove('armeabi-v7a')
+              }
+              if (platform.equals('android-x86')) {
+                excludeList.remove('x86')
+              }
+              if (platform.equals('android-x64')) {
+                excludeList.remove('x86_64')
+              }
+            }
+
+            println "[OPENCV_CORE] only support platform : $targetPlatforms"
+            println "[OPENCV_CORE] exclude abi : $excludeList"
+            packagingOptions {
+              excludeList.each {
+                exclude "lib/$it/*"
+              }
             }
           }
         }

--- a/packages/opencv_dart/android/build.gradle
+++ b/packages/opencv_dart/android/build.gradle
@@ -78,6 +78,36 @@ android {
               }
             }
           }
+
+          def targetPlatforms = project.getProperty('target-platform').split(',') as List
+          if (!targetPlatforms.isEmpty()) {
+            // ignore not use abi
+            def excludeList = ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
+
+            targetPlatforms.each { platform ->
+              if (platform.equals('android-arm64')) {
+                excludeList.remove('arm64-v8a')
+              }
+              if (platform.equals('android-arm')) {
+                excludeList.remove('armeabi-v7a')
+              }
+              if (platform.equals('android-x86')) {
+                excludeList.remove('x86')
+              }
+              if (platform.equals('android-x64')) {
+                excludeList.remove('x86_64')
+              }
+            }
+
+            println "[OPENCV_CORE] only support platform : $targetPlatforms"
+            println "[OPENCV_CORE] exclude abi : $excludeList"
+            packagingOptions {
+              excludeList.each {
+                exclude "lib/$it/*"
+              }
+            }
+          }
+        }
       }
     }
 }


### PR DESCRIPTION
build android apk without unuse abi dynamic file

same issue like #211 , oepncv_dart 1.4.1 not support this way , so provide support for this part , and dont use env `OPENCV_DART_ANDROID_ENABLED_ABI` anymore

case :

**before**
```
$ flutter build apk          

[OPENCV_CORE] only support platform : [android-arm, android-arm64, android-x64]
[OPENCV_CORE] exclude abi : [x86]
✓ Built build/app/outputs/flutter-apk/app-release.apk (195.5MB)

```

**after**
```
$ flutter build apk --release --target-platform=android-arm64,android-arm 

[OPENCV_CORE] only support platform : [android-arm64, android-arm]
[OPENCV_CORE] exclude abi : [x86, x86_64]
✓ Built build/app/outputs/flutter-apk/app-release.apk (136.2MB)

```
