### PR TITLE
added API for approxPolyN

### DIFF
--- a/packages/dartcv/lib/src/g/imgproc.g.dart
+++ b/packages/dartcv/lib/src/g/imgproc.g.dart
@@ -1109,6 +1109,40 @@ class CvNativeImgproc {
   late final _cv_approxPolyDP = _cv_approxPolyDPPtr.asFunction<
       ffi.Pointer<CvStatus> Function(VecPoint, double, bool, ffi.Pointer<VecPoint>, imp1.CvCallback_0)>();
 
+  ffi.Pointer<CvStatus> cv_approxPolyN(
+    VecPoint curve,
+    int n_segments,
+    double epsilon_percentage,
+    bool ensure_convex,
+    ffi.Pointer<VecPoint> rval,
+    imp1.CvCallback_0 callback,
+    ) {
+      return _cv_approxPolyN(curve, n_segments, epsilon_percentage, ensure_convex, rval, callback);
+  }
+
+  late final _cv_approxPolyNPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.Pointer<CvStatus> Function(
+        VecPoint, ffi.Int, ffi.Float, ffi.Bool, ffi.Pointer<VecPoint>, imp1.CvCallback_0)>>('cv_approxPolyN');
+  late final _cv_approxPolyN = _cv_approxPolyNPtr.asFunction<ffi.Pointer<CvStatus> Function(VecPoint, int, double, bool, ffi.Pointer<VecPoint>, imp1.CvCallback_0)>();
+
+  ffi.Pointer<CvStatus> cv_approxPolyN2f(
+    VecPoint2f curve,
+    int n_segments,
+    double epsilon_percentage,
+    bool ensure_convex,
+    ffi.Pointer<VecPoint2f> rval,
+    imp1.CvCallback_0 callback,
+    ) {
+      return _cv_approxPolyN2f(curve, n_segments, epsilon_percentage, ensure_convex, rval, callback);
+  }
+
+  late final _cv_approxPolyN2fPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.Pointer<CvStatus> Function(
+        VecPoint2f, ffi.Int, ffi.Float, ffi.Bool, ffi.Pointer<VecPoint2f>, imp1.CvCallback_0)>>('cv_approxPolyN2f');
+  late final _cv_approxPolyN2f = _cv_approxPolyN2fPtr.asFunction<ffi.Pointer<CvStatus> Function(VecPoint2f, int, double, bool, ffi.Pointer<VecPoint2f>, imp1.CvCallback_0)>();
+
   ffi.Pointer<CvStatus> cv_arcLength(
     VecPoint curve,
     bool is_closed,

--- a/packages/dartcv/lib/src/imgproc/imgproc.dart
+++ b/packages/dartcv/lib/src/imgproc/imgproc.dart
@@ -37,6 +37,30 @@ VecPoint approxPolyDP(VecPoint curve, double epsilon, bool closed) {
   return vec;
 }
 
+/// ApproxPolyN approximates a polygon with a convex hull with a specified accuracy and number of sides. 
+/// 
+/// For further details, please see:
+/// 
+/// https://docs.opencv.org/4.x/d3/dc0/group__imgproc__shape.html#ga88981607a2d61b95074688aac55625cc
+
+VecPoint2f approxPolyN2f(VecPoint2f curve, int n_segments, {double epsilon_percentage=-1.0, bool ensure_convex=true}) {
+  final vec = VecPoint2f();
+  cvRun(() => cimgproc.cv_approxPolyN2f(curve.ref, n_segments, epsilon_percentage, ensure_convex, vec.ptr, ffi.nullptr));
+  return vec;
+}
+
+/// ApproxPolyN approximates a polygon with a convex hull with a specified accuracy and number of sides. 
+/// 
+/// For further details, please see:
+/// 
+/// https://docs.opencv.org/4.x/d3/dc0/group__imgproc__shape.html#ga88981607a2d61b95074688aac55625cc
+
+VecPoint approxPolyN(VecPoint curve, int n_segments, {double epsilon_percentage=-1.0, bool ensure_convex=true}) {
+  final vec = VecPoint();
+  cvRun(() => cimgproc.cv_approxPolyN(curve.ref, n_segments, epsilon_percentage, ensure_convex, vec.ptr, ffi.nullptr));
+  return vec;
+}
+
 /// ArcLength calculates a contour perimeter or a curve length.
 ///
 /// For further details, please see:


### PR DESCRIPTION
provides the corresponding dart API for the added c wrapper in https://github.com/rainyl/dartcv/pull/24.

Do we need to add any tags/bump versions to make sure that `opencv_dart` is built against a version of `dartcv` that already contains the c wrappers? For my local setup I have overriden the 4.11.0.3 tag in [dartcv](https://github.com/rainyl/dartcv) in my forked repository and have built against that to test things.