### PR TITLE
Bump OpenCV to 4.12.0, add new constructor for FlannBasedMatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ publish/
 *.exe
 libdartcv*
 .DS_STORE
+.ccls-cache/
+example/
 
 # Files and directories created by pub
 .dart_tool/

--- a/packages/dartcv/lib/features2d.dart
+++ b/packages/dartcv/lib/features2d.dart
@@ -6,3 +6,4 @@ library dartcv.features2d;
 
 export 'src/features2d/features2d.dart';
 export 'src/features2d/features2d_async.dart';
+export 'src/g/features2d.g.dart' show FlannIndexType, FlannAlgorithm, FlannDistance;

--- a/packages/dartcv/lib/src/features2d/features2d.dart
+++ b/packages/dartcv/lib/src/features2d/features2d.dart
@@ -45,6 +45,8 @@ class FlannIndexParams extends CvStruct<cvg.FlannIndexParams> {
           params.set<String>(entry.key, entry.value as String);
         case bool():
           params.set<bool>(entry.key, entry.value as bool);
+        case cvg.FlannAlgorithm():
+          params.set<cvg.FlannAlgorithm>(entry.key, entry.value as cvg.FlannAlgorithm);
         default:
           throw ArgumentError('Value type ${entry.value.runtimeType} is not supported for FlannIndexParams');
       }
@@ -125,7 +127,7 @@ class FlannIndexParams extends CvStruct<cvg.FlannIndexParams> {
         cvg.FlannIndexType.FLANN_INDEX_TYPE_32F || cvg.FlannIndexType.FLANN_INDEX_TYPE_64F => numValues[i],
         cvg.FlannIndexType.FLANN_INDEX_TYPE_BOOL => numValues[i].toInt() != 0,
         cvg.FlannIndexType.FLANN_INDEX_TYPE_STRING => names1[i],
-        cvg.FlannIndexType.FLANN_INDEX_TYPE_ALGORITHM => numValues[i].toInt(),
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_ALGORITHM => cvg.FlannAlgorithm.fromValue(numValues[i].toInt()),
       };
     }
 
@@ -138,33 +140,28 @@ class FlannIndexParams extends CvStruct<cvg.FlannIndexParams> {
     cfeatures2d.cv_flann_IndexParams_setString(ref, ckey, cvalue);
     calloc.free(ckey);
     calloc.free(cvalue);
-    return;
   }
 
   void setInt(String key, int value) {
     final ckey = key.toNativeUtf8().cast<ffi.Char>();
     cfeatures2d.cv_flann_IndexParams_setInt(ref, ckey, value);
     calloc.free(ckey);
-    return;
   }
 
   void setDouble(String key, double value) {
     final ckey = key.toNativeUtf8().cast<ffi.Char>();
     cfeatures2d.cv_flann_IndexParams_setDouble(ref, ckey, value);
     calloc.free(ckey);
-    return;
   }
 
   void setBool(String key, bool value) {
     final ckey = key.toNativeUtf8().cast<ffi.Char>();
     cfeatures2d.cv_flann_IndexParams_setBool(ref, ckey, value);
     calloc.free(ckey);
-    return;
   }
 
-  void setAlgorithm(int value) {
-    cfeatures2d.cv_flann_IndexParams_setAlgorithm(ref, value);
-    return;
+  void setAlgorithm(cvg.FlannAlgorithm value) {
+    cfeatures2d.cv_flann_IndexParams_setAlgorithm(ref, value.value);
   }
 
   T get<T>(String key, [T? defaultValue]) {
@@ -180,15 +177,6 @@ class FlannIndexParams extends CvStruct<cvg.FlannIndexParams> {
   }
 
   void set<T>(String key, T value) {
-    if (key == 'algorithm') {
-      if (value is int) {
-        setAlgorithm(value as int);
-        return;
-      } else {
-        throw ArgumentError("`algorithm` is a special preserved key for `setAlgorithm()` "
-            "which only accepts `int`, but got value type: ${T.runtimeType}");
-      }
-    }
     switch (value) {
       case int():
         setInt(key, value);
@@ -198,6 +186,8 @@ class FlannIndexParams extends CvStruct<cvg.FlannIndexParams> {
         setString(key, value);
       case bool():
         setBool(key, value);
+      case cvg.FlannAlgorithm():
+        setAlgorithm(value);
       default:
         throw ArgumentError("Unsupported type: ${value.runtimeType}");
     }

--- a/packages/dartcv/lib/src/features2d/features2d.dart
+++ b/packages/dartcv/lib/src/features2d/features2d.dart
@@ -192,6 +192,11 @@ class FlannIndexParams extends CvStruct<cvg.FlannIndexParams> {
         throw ArgumentError("Unsupported type: ${value.runtimeType}");
     }
   }
+
+  @override
+  String toString() {
+    return "FlannIndexParams(address=0x${ptr.address.toRadixString(16)})";
+  }
 }
 
 class FlannSearchParams extends FlannIndexParams {
@@ -269,21 +274,25 @@ class FlannSearchParams extends FlannIndexParams {
 }
 
 class FlannKDTreeIndexParams extends FlannIndexParams {
-  FlannKDTreeIndexParams.fromPointer(
-    super.ptr, [
-    super.attach = true,
-  ]) : super.fromPointer();
+  FlannKDTreeIndexParams.fromPointer(super.ptr, [super.attach = true]) : super.fromPointer();
 
-  factory FlannKDTreeIndexParams({
-    int trees = 4,
-  }) {
+  factory FlannKDTreeIndexParams({int trees = 4}) {
     final p = calloc<cvg.FlannIndexParams>();
     cvRun(() => cfeatures2d.cv_flann_IndexParams_create(p));
     final params = FlannKDTreeIndexParams.fromPointer(p);
 
+    params.setAlgorithm(cvg.FlannAlgorithm.FLANN_INDEX_KDTREE);
     params.setInt('trees', trees);
 
     return params;
+  }
+
+  int get trees => getInt("trees");
+  set trees(int value) => setInt("trees", value);
+
+  @override
+  String toString() {
+    return 'FlannKDTreeIndexParams(address=0x${ptr.address.toRadixString(16)}, trees=$trees)';
   }
 }
 

--- a/packages/dartcv/lib/src/features2d/features2d.dart
+++ b/packages/dartcv/lib/src/features2d/features2d.dart
@@ -20,6 +20,283 @@ import '../g/constants.g.dart';
 import '../g/features2d.g.dart' as cvg;
 import '../native_lib.dart' show cfeatures2d;
 
+class FlannIndexParams extends CvStruct<cvg.FlannIndexParams> {
+  FlannIndexParams.fromPointer(cvg.FlannIndexParamsPtr ptr, [bool attach = true]) : super.fromPointer(ptr) {
+    if (attach) {
+      finalizer.attach(this, ptr.cast());
+    }
+  }
+
+  factory FlannIndexParams.empty() {
+    final p = calloc<cvg.FlannIndexParams>();
+    cvRun(() => cfeatures2d.cv_flann_IndexParams_create(p));
+    return FlannIndexParams.fromPointer(p);
+  }
+
+  factory FlannIndexParams.fromMap(Map<String, dynamic> map) {
+    final params = FlannIndexParams.empty();
+    for (final entry in map.entries) {
+      switch (entry.value) {
+        case int():
+          params.set<int>(entry.key, entry.value as int);
+        case double():
+          params.set<double>(entry.key, entry.value as double);
+        case String():
+          params.set<String>(entry.key, entry.value as String);
+        case bool():
+          params.set<bool>(entry.key, entry.value as bool);
+        default:
+          throw ArgumentError('Value type ${entry.value.runtimeType} is not supported for FlannIndexParams');
+      }
+    }
+    return params;
+  }
+
+  static final finalizer = OcvFinalizer<cvg.FlannIndexParamsPtr>(
+    cfeatures2d.addresses.cv_flann_IndexParams_close,
+  );
+
+  @override
+  cvg.FlannIndexParams get ref => ptr.ref;
+
+  String getString(String key, [String defaultValue = ""]) {
+    final ckey = key.toNativeUtf8().cast<ffi.Char>();
+    final cdefault = defaultValue.toNativeUtf8().cast<ffi.Char>();
+    final crval = calloc<ffi.Pointer<ffi.Char>>();
+    cfeatures2d.cv_flann_IndexParams_getString(ref, ckey, cdefault, crval);
+    calloc.free(ckey);
+    calloc.free(cdefault);
+
+    final rval = crval.value.cast<ffi.Char>().toDartString();
+    calloc.free(crval);
+    return rval;
+  }
+
+  int getInt(String key, [int defaultValue = -1]) {
+    final ckey = key.toNativeUtf8().cast<ffi.Char>();
+    final crval = calloc<ffi.Int>();
+    cfeatures2d.cv_flann_IndexParams_getInt(ref, ckey, defaultValue, crval);
+    calloc.free(ckey);
+    final rval = crval.value;
+    calloc.free(crval);
+    return rval;
+  }
+
+  double getDouble(String key, [double defaultValue = -1]) {
+    final ckey = key.toNativeUtf8().cast<ffi.Char>();
+    final crval = calloc<ffi.Double>();
+    cfeatures2d.cv_flann_IndexParams_getDouble(ref, ckey, defaultValue, crval);
+    calloc.free(ckey);
+    final rval = crval.value;
+    calloc.free(crval);
+    return rval;
+  }
+
+  // bool getBool(String key, [bool defaultValue = false]) {
+  //   final ckey = key.toNativeUtf8().cast<ffi.Char>();
+  //   final crval = calloc<ffi.Bool>();
+  //   cfeatures2d.cv_flann_IndexParams_getBool(ref, ckey, defaultValue, crval);
+  //   calloc.free(ckey);
+  //   final rval = crval.value;
+  //   calloc.free(crval);
+  //   return rval;
+  // }
+
+  Map<String, dynamic> getAll() {
+    final names = VecVecChar();
+    final types = VecI32();
+    final strValues = VecVecChar();
+    final numValues = VecF64();
+
+    cfeatures2d.cv_flann_IndexParams_getAll(ref, names.ptr, types.ptr, strValues.ptr, numValues.ptr);
+
+    final rval = <String, dynamic>{};
+    final names1 = names.asStringList();
+    for (var i = 0; i < names1.length; i++) {
+      final name = names1[i];
+      final type = types[i];
+      rval[name] = switch (cvg.FlannIndexType.fromValue(type)) {
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_8U ||
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_8S ||
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_16U ||
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_16S ||
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_32S =>
+          numValues[i].toInt(),
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_32F || cvg.FlannIndexType.FLANN_INDEX_TYPE_64F => numValues[i],
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_BOOL => numValues[i].toInt() != 0,
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_STRING => names1[i],
+        cvg.FlannIndexType.FLANN_INDEX_TYPE_ALGORITHM => numValues[i].toInt(),
+      };
+    }
+
+    return rval;
+  }
+
+  void setString(String key, String value) {
+    final ckey = key.toNativeUtf8().cast<ffi.Char>();
+    final cvalue = value.toNativeUtf8().cast<ffi.Char>();
+    cfeatures2d.cv_flann_IndexParams_setString(ref, ckey, cvalue);
+    calloc.free(ckey);
+    calloc.free(cvalue);
+    return;
+  }
+
+  void setInt(String key, int value) {
+    final ckey = key.toNativeUtf8().cast<ffi.Char>();
+    cfeatures2d.cv_flann_IndexParams_setInt(ref, ckey, value);
+    calloc.free(ckey);
+    return;
+  }
+
+  void setDouble(String key, double value) {
+    final ckey = key.toNativeUtf8().cast<ffi.Char>();
+    cfeatures2d.cv_flann_IndexParams_setDouble(ref, ckey, value);
+    calloc.free(ckey);
+    return;
+  }
+
+  void setBool(String key, bool value) {
+    final ckey = key.toNativeUtf8().cast<ffi.Char>();
+    cfeatures2d.cv_flann_IndexParams_setBool(ref, ckey, value);
+    calloc.free(ckey);
+    return;
+  }
+
+  void setAlgorithm(int value) {
+    cfeatures2d.cv_flann_IndexParams_setAlgorithm(ref, value);
+    return;
+  }
+
+  T get<T>(String key, [T? defaultValue]) {
+    if (T == int) {
+      return getInt(key, defaultValue as int? ?? -1) as T;
+    } else if (T == double) {
+      return getDouble(key, defaultValue as double? ?? -1.0) as T;
+    } else if (T == String) {
+      return getString(key, defaultValue as String? ?? "") as T;
+    } else {
+      throw ArgumentError("Unsupported type: ${T.runtimeType}");
+    }
+  }
+
+  void set<T>(String key, T value) {
+    if (key == 'algorithm') {
+      if (value is int) {
+        setAlgorithm(value as int);
+        return;
+      } else {
+        throw ArgumentError("`algorithm` is a special preserved key for `setAlgorithm()` "
+            "which only accepts `int`, but got value type: ${T.runtimeType}");
+      }
+    }
+    switch (value) {
+      case int():
+        setInt(key, value);
+      case double():
+        setDouble(key, value);
+      case String():
+        setString(key, value);
+      case bool():
+        setBool(key, value);
+      default:
+        throw ArgumentError("Unsupported type: ${value.runtimeType}");
+    }
+  }
+}
+
+class FlannSearchParams extends FlannIndexParams {
+  FlannSearchParams.fromPointer(
+    super.ptr,
+    int checks,
+    double eps,
+    bool sorted,
+    bool exploreAllTrees, [
+    super.attach = true,
+  ])  : _checks = checks,
+        _eps = eps,
+        _sorted = sorted,
+        _exploreAllTrees = exploreAllTrees,
+        super.fromPointer();
+
+  factory FlannSearchParams({
+    int checks = 32,
+    double eps = 0.0,
+    bool sorted = true,
+    bool exploreAllTrees = false,
+  }) {
+    final p = calloc<cvg.FlannIndexParams>();
+    cvRun(() => cfeatures2d.cv_flann_IndexParams_create(p));
+    final params = FlannSearchParams.fromPointer(p, checks, eps, sorted, exploreAllTrees);
+
+    params.setInt('checks', checks);
+    params.setDouble('eps', eps);
+
+    params.setInt('sorted', sorted ? 1 : 0);
+    params.setInt('explore_all_trees', exploreAllTrees ? 1 : 0);
+
+    return params;
+  }
+
+  int _checks;
+  double _eps;
+  bool _sorted;
+  bool _exploreAllTrees;
+
+  int get checks => _checks;
+  double get eps => _eps;
+  bool get sorted => _sorted;
+  bool get exploreAllTrees => _exploreAllTrees;
+
+  set checks(int value) {
+    _checks = value;
+    setInt("checks", value);
+  }
+
+  set eps(double value) {
+    _eps = value;
+    setDouble("eps", value);
+  }
+
+  set sorted(bool value) {
+    _sorted = value;
+    setInt("sorted", value ? 1 : 0);
+  }
+
+  set exploreAllTrees(bool value) {
+    _exploreAllTrees = value;
+    setInt("explore_all_trees", value ? 1 : 0);
+  }
+
+  @override
+  String toString() {
+    return "FlannSearchParams("
+        "address=0x${ptr.address.toRadixString(16)}, "
+        "checks=$checks, "
+        "eps=$eps, "
+        "sorted=$sorted, "
+        "exploreAllTrees=$exploreAllTrees)";
+  }
+}
+
+class FlannKDTreeIndexParams extends FlannIndexParams {
+  FlannKDTreeIndexParams.fromPointer(
+    super.ptr, [
+    super.attach = true,
+  ]) : super.fromPointer();
+
+  factory FlannKDTreeIndexParams({
+    int trees = 4,
+  }) {
+    final p = calloc<cvg.FlannIndexParams>();
+    cvRun(() => cfeatures2d.cv_flann_IndexParams_create(p));
+    final params = FlannKDTreeIndexParams.fromPointer(p);
+
+    params.setInt('trees', trees);
+
+    return params;
+  }
+}
+
 /// AKAZE is a wrapper around the cv::AKAZE algorithm.
 class AKAZE extends CvStruct<cvg.AKAZE> {
   AKAZE._(cvg.AKAZEPtr ptr, [bool attach = true]) : super.fromPointer(ptr) {
@@ -482,7 +759,7 @@ class ORB extends CvStruct<cvg.ORB> {
 
 class SimpleBlobDetectorParams extends CvStruct<cvg.SimpleBlobDetectorParams> {
   SimpleBlobDetectorParams._(ffi.Pointer<cvg.SimpleBlobDetectorParams> ptr, [bool attach = true])
-    : super.fromPointer(ptr) {
+      : super.fromPointer(ptr) {
     if (attach) {
       finalizer.attach(this, ptr.cast(), detach: this);
     }
@@ -544,30 +821,31 @@ class SimpleBlobDetectorParams extends CvStruct<cvg.SimpleBlobDetectorParams> {
   }
 
   factory SimpleBlobDetectorParams.fromNative(cvg.SimpleBlobDetectorParams r) => SimpleBlobDetectorParams(
-    blobColor: r.blobColor,
-    filterByArea: r.filterByArea,
-    filterByCircularity: r.filterByCircularity,
-    filterByColor: r.filterByColor,
-    filterByConvexity: r.filterByConvexity,
-    filterByInertia: r.filterByInertia,
-    maxArea: r.maxArea,
-    maxCircularity: r.maxCircularity,
-    maxConvexity: r.maxConvexity,
-    maxInertiaRatio: r.maxInertiaRatio,
-    maxThreshold: r.maxThreshold,
-    minArea: r.minArea,
-    minCircularity: r.minCircularity,
-    minConvexity: r.minConvexity,
-    minDistBetweenBlobs: r.minDistBetweenBlobs,
-    minInertiaRatio: r.minInertiaRatio,
-    minRepeatability: r.minRepeatability,
-    minThreshold: r.minThreshold,
-    thresholdStep: r.thresholdStep,
-  );
+        blobColor: r.blobColor,
+        filterByArea: r.filterByArea,
+        filterByCircularity: r.filterByCircularity,
+        filterByColor: r.filterByColor,
+        filterByConvexity: r.filterByConvexity,
+        filterByInertia: r.filterByInertia,
+        maxArea: r.maxArea,
+        maxCircularity: r.maxCircularity,
+        maxConvexity: r.maxConvexity,
+        maxInertiaRatio: r.maxInertiaRatio,
+        maxThreshold: r.maxThreshold,
+        minArea: r.minArea,
+        minCircularity: r.minCircularity,
+        minConvexity: r.minConvexity,
+        minDistBetweenBlobs: r.minDistBetweenBlobs,
+        minInertiaRatio: r.minInertiaRatio,
+        minRepeatability: r.minRepeatability,
+        minThreshold: r.minThreshold,
+        thresholdStep: r.thresholdStep,
+      );
   factory SimpleBlobDetectorParams.fromPointer(
     ffi.Pointer<cvg.SimpleBlobDetectorParams> p, [
     bool attach = true,
-  ]) => SimpleBlobDetectorParams._(p, attach);
+  ]) =>
+      SimpleBlobDetectorParams._(p, attach);
 
   @override
   cvg.SimpleBlobDetectorParams get ref => ptr.ref;
@@ -638,21 +916,21 @@ class SimpleBlobDetectorParams extends CvStruct<cvg.SimpleBlobDetectorParams> {
 
   @override
   List<num> get props => [
-    maxArea,
-    minArea,
-    minConvexity,
-    maxConvexity,
-    minInertiaRatio,
-    maxInertiaRatio,
-    minThreshold,
-    maxThreshold,
-    thresholdStep,
-    minDistBetweenBlobs,
-    minRepeatability,
-    minThreshold,
-    thresholdStep,
-    minDistBetweenBlobs,
-  ];
+        maxArea,
+        minArea,
+        minConvexity,
+        maxConvexity,
+        minInertiaRatio,
+        maxInertiaRatio,
+        minThreshold,
+        maxThreshold,
+        thresholdStep,
+        minDistBetweenBlobs,
+        minRepeatability,
+        minThreshold,
+        thresholdStep,
+        minDistBetweenBlobs,
+      ];
 }
 
 /// SimpleBlobDetector is a wrapper around the cv::SimpleBlobDetector.
@@ -778,6 +1056,19 @@ class FlannBasedMatcher extends CvStruct<cvg.FlannBasedMatcher> {
   factory FlannBasedMatcher.empty() {
     final p = calloc<cvg.FlannBasedMatcher>();
     cvRun(() => cfeatures2d.cv_FlannBasedMatcher_create(p));
+    return FlannBasedMatcher._(p);
+  }
+
+  factory FlannBasedMatcher.create({FlannIndexParams? indexParams, FlannSearchParams? searchParams}) {
+    if (indexParams == null && searchParams == null) {
+      return FlannBasedMatcher.empty();
+    }
+
+    indexParams = indexParams ?? FlannKDTreeIndexParams();
+    searchParams = searchParams ?? FlannSearchParams();
+
+    final p = calloc<cvg.FlannBasedMatcher>();
+    cvRun(() => cfeatures2d.cv_FlannBasedMatcher_create_1(p, indexParams!.ref, searchParams!.ref));
     return FlannBasedMatcher._(p);
   }
 

--- a/packages/dartcv/lib/src/g/features2d.g.dart
+++ b/packages/dartcv/lib/src/g/features2d.g.dart
@@ -471,6 +471,29 @@ class CvNativeFeatures2d {
       _cv_FlannBasedMatcher_createPtr.asFunction<
           ffi.Pointer<CvStatus> Function(ffi.Pointer<FlannBasedMatcher>)>();
 
+  ffi.Pointer<CvStatus> cv_FlannBasedMatcher_create_1(
+    ffi.Pointer<FlannBasedMatcher> rval,
+    FlannIndexParams indexParams,
+    FlannIndexParams searchParams,
+  ) {
+    return _cv_FlannBasedMatcher_create_1(
+      rval,
+      indexParams,
+      searchParams,
+    );
+  }
+
+  late final _cv_FlannBasedMatcher_create_1Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<CvStatus> Function(
+              ffi.Pointer<FlannBasedMatcher>,
+              FlannIndexParams,
+              FlannIndexParams)>>('cv_FlannBasedMatcher_create_1');
+  late final _cv_FlannBasedMatcher_create_1 =
+      _cv_FlannBasedMatcher_create_1Ptr.asFunction<
+          ffi.Pointer<CvStatus> Function(ffi.Pointer<FlannBasedMatcher>,
+              FlannIndexParams, FlannIndexParams)>();
+
   ffi.Pointer<CvStatus> cv_FlannBasedMatcher_knnMatch(
     FlannBasedMatcher self,
     Mat query,
@@ -1060,6 +1083,272 @@ class CvNativeFeatures2d {
       ffi.Pointer<CvStatus> Function(Mat, VecKeyPoint, Mat, VecKeyPoint,
           VecDMatch, Mat, Scalar, Scalar, VecChar, int, imp$1.CvCallback_0)>();
 
+  void cv_flann_IndexParams_close(
+    FlannIndexParamsPtr self,
+  ) {
+    return _cv_flann_IndexParams_close(
+      self,
+    );
+  }
+
+  late final _cv_flann_IndexParams_closePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(FlannIndexParamsPtr)>>(
+          'cv_flann_IndexParams_close');
+  late final _cv_flann_IndexParams_close = _cv_flann_IndexParams_closePtr
+      .asFunction<void Function(FlannIndexParamsPtr)>();
+
+  ffi.Pointer<CvStatus> cv_flann_IndexParams_create(
+    ffi.Pointer<FlannIndexParams> rval,
+  ) {
+    return _cv_flann_IndexParams_create(
+      rval,
+    );
+  }
+
+  late final _cv_flann_IndexParams_createPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<CvStatus> Function(
+              ffi.Pointer<FlannIndexParams>)>>('cv_flann_IndexParams_create');
+  late final _cv_flann_IndexParams_create =
+      _cv_flann_IndexParams_createPtr.asFunction<
+          ffi.Pointer<CvStatus> Function(ffi.Pointer<FlannIndexParams>)>();
+
+  void cv_flann_IndexParams_getAll(
+    FlannIndexParams self,
+    ffi.Pointer<VecVecChar> names,
+    ffi.Pointer<VecI32> types,
+    ffi.Pointer<VecVecChar> strValues,
+    ffi.Pointer<VecF64> numValues,
+  ) {
+    return _cv_flann_IndexParams_getAll(
+      self,
+      names,
+      types,
+      strValues,
+      numValues,
+    );
+  }
+
+  late final _cv_flann_IndexParams_getAllPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              FlannIndexParams,
+              ffi.Pointer<VecVecChar>,
+              ffi.Pointer<VecI32>,
+              ffi.Pointer<VecVecChar>,
+              ffi.Pointer<VecF64>)>>('cv_flann_IndexParams_getAll');
+  late final _cv_flann_IndexParams_getAll =
+      _cv_flann_IndexParams_getAllPtr.asFunction<
+          void Function(
+              FlannIndexParams,
+              ffi.Pointer<VecVecChar>,
+              ffi.Pointer<VecI32>,
+              ffi.Pointer<VecVecChar>,
+              ffi.Pointer<VecF64>)>();
+
+  void cv_flann_IndexParams_getDouble(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    double defaultValue,
+    ffi.Pointer<ffi.Double> rval,
+  ) {
+    return _cv_flann_IndexParams_getDouble(
+      self,
+      key,
+      defaultValue,
+      rval,
+    );
+  }
+
+  late final _cv_flann_IndexParams_getDoublePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, ffi.Double,
+              ffi.Pointer<ffi.Double>)>>('cv_flann_IndexParams_getDouble');
+  late final _cv_flann_IndexParams_getDouble =
+      _cv_flann_IndexParams_getDoublePtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, double,
+              ffi.Pointer<ffi.Double>)>();
+
+  void cv_flann_IndexParams_getInt(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    int defaultValue,
+    ffi.Pointer<ffi.Int> rval,
+  ) {
+    return _cv_flann_IndexParams_getInt(
+      self,
+      key,
+      defaultValue,
+      rval,
+    );
+  }
+
+  late final _cv_flann_IndexParams_getIntPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, ffi.Int,
+              ffi.Pointer<ffi.Int>)>>('cv_flann_IndexParams_getInt');
+  late final _cv_flann_IndexParams_getInt =
+      _cv_flann_IndexParams_getIntPtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, int,
+              ffi.Pointer<ffi.Int>)>();
+
+  void cv_flann_IndexParams_getString(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    ffi.Pointer<ffi.Char> defaultValue,
+    ffi.Pointer<ffi.Pointer<ffi.Char>> rval,
+  ) {
+    return _cv_flann_IndexParams_getString(
+      self,
+      key,
+      defaultValue,
+      rval,
+    );
+  }
+
+  late final _cv_flann_IndexParams_getStringPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+                  ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Pointer<ffi.Char>>)>>(
+      'cv_flann_IndexParams_getString');
+  late final _cv_flann_IndexParams_getString =
+      _cv_flann_IndexParams_getStringPtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+              ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+
+  ffi.Pointer<ffi.Void> cv_flann_IndexParams_params_ptr(
+    FlannIndexParams self,
+  ) {
+    return _cv_flann_IndexParams_params_ptr(
+      self,
+    );
+  }
+
+  late final _cv_flann_IndexParams_params_ptrPtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<ffi.Void> Function(FlannIndexParams)>>(
+      'cv_flann_IndexParams_params_ptr');
+  late final _cv_flann_IndexParams_params_ptr =
+      _cv_flann_IndexParams_params_ptrPtr
+          .asFunction<ffi.Pointer<ffi.Void> Function(FlannIndexParams)>();
+
+  void cv_flann_IndexParams_setAlgorithm(
+    FlannIndexParams self,
+    int value,
+  ) {
+    return _cv_flann_IndexParams_setAlgorithm(
+      self,
+      value,
+    );
+  }
+
+  late final _cv_flann_IndexParams_setAlgorithmPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(FlannIndexParams, ffi.Int)>>(
+          'cv_flann_IndexParams_setAlgorithm');
+  late final _cv_flann_IndexParams_setAlgorithm =
+      _cv_flann_IndexParams_setAlgorithmPtr
+          .asFunction<void Function(FlannIndexParams, int)>();
+
+  void cv_flann_IndexParams_setBool(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    bool value,
+  ) {
+    return _cv_flann_IndexParams_setBool(
+      self,
+      key,
+      value,
+    );
+  }
+
+  late final _cv_flann_IndexParams_setBoolPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+              ffi.Bool)>>('cv_flann_IndexParams_setBool');
+  late final _cv_flann_IndexParams_setBool =
+      _cv_flann_IndexParams_setBoolPtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, bool)>();
+
+  void cv_flann_IndexParams_setDouble(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    double value,
+  ) {
+    return _cv_flann_IndexParams_setDouble(
+      self,
+      key,
+      value,
+    );
+  }
+
+  late final _cv_flann_IndexParams_setDoublePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+              ffi.Double)>>('cv_flann_IndexParams_setDouble');
+  late final _cv_flann_IndexParams_setDouble =
+      _cv_flann_IndexParams_setDoublePtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, double)>();
+
+  void cv_flann_IndexParams_setFloat(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    double value,
+  ) {
+    return _cv_flann_IndexParams_setFloat(
+      self,
+      key,
+      value,
+    );
+  }
+
+  late final _cv_flann_IndexParams_setFloatPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+              ffi.Float)>>('cv_flann_IndexParams_setFloat');
+  late final _cv_flann_IndexParams_setFloat =
+      _cv_flann_IndexParams_setFloatPtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, double)>();
+
+  void cv_flann_IndexParams_setInt(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    int value,
+  ) {
+    return _cv_flann_IndexParams_setInt(
+      self,
+      key,
+      value,
+    );
+  }
+
+  late final _cv_flann_IndexParams_setIntPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+              ffi.Int)>>('cv_flann_IndexParams_setInt');
+  late final _cv_flann_IndexParams_setInt =
+      _cv_flann_IndexParams_setIntPtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>, int)>();
+
+  void cv_flann_IndexParams_setString(
+    FlannIndexParams self,
+    ffi.Pointer<ffi.Char> key,
+    ffi.Pointer<ffi.Char> value,
+  ) {
+    return _cv_flann_IndexParams_setString(
+      self,
+      key,
+      value,
+    );
+  }
+
+  late final _cv_flann_IndexParams_setStringPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+              ffi.Pointer<ffi.Char>)>>('cv_flann_IndexParams_setString');
+  late final _cv_flann_IndexParams_setString =
+      _cv_flann_IndexParams_setStringPtr.asFunction<
+          void Function(FlannIndexParams, ffi.Pointer<ffi.Char>,
+              ffi.Pointer<ffi.Char>)>();
+
   late final addresses = _SymbolAddresses(this);
 }
 
@@ -1093,6 +1382,8 @@ class _SymbolAddresses {
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(SimpleBlobDetectorPtr)>>
       get cv_SimpleBlobDetector_close =>
           _library._cv_SimpleBlobDetector_closePtr;
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(FlannIndexParamsPtr)>>
+      get cv_flann_IndexParams_close => _library._cv_flann_IndexParams_closePtr;
 }
 
 final class AKAZE extends ffi.Struct {
@@ -1131,6 +1422,51 @@ final class FlannBasedMatcher extends ffi.Struct {
 }
 
 typedef FlannBasedMatcherPtr = ffi.Pointer<FlannBasedMatcher>;
+
+final class FlannIndexParams extends ffi.Struct {
+  external ffi.Pointer<ffi.Void> ptr;
+}
+
+typedef FlannIndexParamsPtr = ffi.Pointer<FlannIndexParams>;
+
+enum FlannIndexType {
+  FLANN_INDEX_TYPE_8U(0),
+  FLANN_INDEX_TYPE_8S(1),
+  FLANN_INDEX_TYPE_16U(2),
+  FLANN_INDEX_TYPE_16S(3),
+  FLANN_INDEX_TYPE_32S(4),
+  FLANN_INDEX_TYPE_32F(5),
+  FLANN_INDEX_TYPE_64F(6),
+  FLANN_INDEX_TYPE_STRING(7),
+  FLANN_INDEX_TYPE_BOOL(8),
+  FLANN_INDEX_TYPE_ALGORITHM(9);
+
+  static const LAST_VALUE_FLANN_INDEX_TYPE = FLANN_INDEX_TYPE_ALGORITHM;
+
+  final int value;
+  const FlannIndexType(this.value);
+
+  static FlannIndexType fromValue(int value) => switch (value) {
+        0 => FLANN_INDEX_TYPE_8U,
+        1 => FLANN_INDEX_TYPE_8S,
+        2 => FLANN_INDEX_TYPE_16U,
+        3 => FLANN_INDEX_TYPE_16S,
+        4 => FLANN_INDEX_TYPE_32S,
+        5 => FLANN_INDEX_TYPE_32F,
+        6 => FLANN_INDEX_TYPE_64F,
+        7 => FLANN_INDEX_TYPE_STRING,
+        8 => FLANN_INDEX_TYPE_BOOL,
+        9 => FLANN_INDEX_TYPE_ALGORITHM,
+        _ => throw ArgumentError('Unknown value for FlannIndexType: $value'),
+      };
+
+  @override
+  String toString() {
+    if (this == FLANN_INDEX_TYPE_ALGORITHM)
+      return "FlannIndexType.FLANN_INDEX_TYPE_ALGORITHM, FlannIndexType.LAST_VALUE_FLANN_INDEX_TYPE";
+    return super.toString();
+  }
+}
 
 final class GFTTDetector extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
@@ -1230,5 +1566,8 @@ final class SimpleBlobDetectorParams extends ffi.Struct {
 typedef SimpleBlobDetectorPtr = ffi.Pointer<SimpleBlobDetector>;
 typedef VecChar = imp$1.VecChar;
 typedef VecDMatch = imp$1.VecDMatch;
+typedef VecF64 = imp$1.VecF64;
+typedef VecI32 = imp$1.VecI32;
 typedef VecKeyPoint = imp$1.VecKeyPoint;
+typedef VecVecChar = imp$1.VecVecChar;
 typedef VecVecDMatch = imp$1.VecVecDMatch;

--- a/packages/dartcv/lib/src/g/features2d.g.dart
+++ b/packages/dartcv/lib/src/g/features2d.g.dart
@@ -1417,11 +1417,87 @@ final class FastFeatureDetector extends ffi.Struct {
 
 typedef FastFeatureDetectorPtr = ffi.Pointer<FastFeatureDetector>;
 
+enum FlannAlgorithm {
+  FLANN_INDEX_LINEAR(0),
+  FLANN_INDEX_KDTREE(1),
+  FLANN_INDEX_KMEANS(2),
+  FLANN_INDEX_COMPOSITE(3),
+  FLANN_INDEX_KDTREE_SINGLE(4),
+  FLANN_INDEX_HIERARCHICAL(5),
+  FLANN_INDEX_LSH(6),
+  FLANN_INDEX_SAVED(254),
+  FLANN_INDEX_AUTOTUNED(255);
+
+  final int value;
+  const FlannAlgorithm(this.value);
+
+  static FlannAlgorithm fromValue(int value) => switch (value) {
+        0 => FLANN_INDEX_LINEAR,
+        1 => FLANN_INDEX_KDTREE,
+        2 => FLANN_INDEX_KMEANS,
+        3 => FLANN_INDEX_COMPOSITE,
+        4 => FLANN_INDEX_KDTREE_SINGLE,
+        5 => FLANN_INDEX_HIERARCHICAL,
+        6 => FLANN_INDEX_LSH,
+        254 => FLANN_INDEX_SAVED,
+        255 => FLANN_INDEX_AUTOTUNED,
+        _ => throw ArgumentError('Unknown value for FlannAlgorithm: $value'),
+      };
+}
+
 final class FlannBasedMatcher extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
 
 typedef FlannBasedMatcherPtr = ffi.Pointer<FlannBasedMatcher>;
+
+enum FlannDistance {
+  FLANN_DIST_EUCLIDEAN(1),
+  FLANN_DIST_MANHATTAN(2),
+  FLANN_DIST_MINKOWSKI(3),
+  FLANN_DIST_MAX(4),
+  FLANN_DIST_HIST_INTERSECT(5),
+  FLANN_DIST_HELLINGER(6),
+  FLANN_DIST_CHI_SQUARE(7),
+  FLANN_DIST_KULLBACK_LEIBLER(8),
+  FLANN_DIST_HAMMING(9),
+  FLANN_DIST_DNAMMING(10);
+
+  static const FLANN_DIST_L2 = FLANN_DIST_EUCLIDEAN;
+  static const FLANN_DIST_L1 = FLANN_DIST_MANHATTAN;
+  static const FLANN_DIST_CS = FLANN_DIST_CHI_SQUARE;
+  static const FLANN_DIST_KL = FLANN_DIST_KULLBACK_LEIBLER;
+
+  final int value;
+  const FlannDistance(this.value);
+
+  static FlannDistance fromValue(int value) => switch (value) {
+        1 => FLANN_DIST_EUCLIDEAN,
+        2 => FLANN_DIST_MANHATTAN,
+        3 => FLANN_DIST_MINKOWSKI,
+        4 => FLANN_DIST_MAX,
+        5 => FLANN_DIST_HIST_INTERSECT,
+        6 => FLANN_DIST_HELLINGER,
+        7 => FLANN_DIST_CHI_SQUARE,
+        8 => FLANN_DIST_KULLBACK_LEIBLER,
+        9 => FLANN_DIST_HAMMING,
+        10 => FLANN_DIST_DNAMMING,
+        _ => throw ArgumentError('Unknown value for FlannDistance: $value'),
+      };
+
+  @override
+  String toString() {
+    if (this == FLANN_DIST_EUCLIDEAN)
+      return "FlannDistance.FLANN_DIST_EUCLIDEAN, FlannDistance.FLANN_DIST_L2";
+    if (this == FLANN_DIST_MANHATTAN)
+      return "FlannDistance.FLANN_DIST_MANHATTAN, FlannDistance.FLANN_DIST_L1";
+    if (this == FLANN_DIST_CHI_SQUARE)
+      return "FlannDistance.FLANN_DIST_CHI_SQUARE, FlannDistance.FLANN_DIST_CS";
+    if (this == FLANN_DIST_KULLBACK_LEIBLER)
+      return "FlannDistance.FLANN_DIST_KULLBACK_LEIBLER, FlannDistance.FLANN_DIST_KL";
+    return super.toString();
+  }
+}
 
 final class FlannIndexParams extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;

--- a/packages/dartcv/lib/src/g/features2d.yaml
+++ b/packages/dartcv/lib/src/g/features2d.yaml
@@ -4,6 +4,10 @@ files:
     used-config:
       ffi-native: false
     symbols:
+      c:@E@FlannAlgorithm:
+        name: FlannAlgorithm
+      c:@E@FlannDistance:
+        name: FlannDistance
       c:@E@FlannIndexType:
         name: FlannIndexType
       c:@F@cv_AKAZE_close:

--- a/packages/dartcv/lib/src/g/features2d.yaml
+++ b/packages/dartcv/lib/src/g/features2d.yaml
@@ -4,6 +4,8 @@ files:
     used-config:
       ffi-native: false
     symbols:
+      c:@E@FlannIndexType:
+        name: FlannIndexType
       c:@F@cv_AKAZE_close:
         name: cv_AKAZE_close
       c:@F@cv_AKAZE_create:
@@ -48,6 +50,8 @@ files:
         name: cv_FlannBasedMatcher_close
       c:@F@cv_FlannBasedMatcher_create:
         name: cv_FlannBasedMatcher_create
+      c:@F@cv_FlannBasedMatcher_create_1:
+        name: cv_FlannBasedMatcher_create_1
       c:@F@cv_FlannBasedMatcher_knnMatch:
         name: cv_FlannBasedMatcher_knnMatch
       c:@F@cv_GFTTDetector_close:
@@ -102,6 +106,32 @@ files:
         name: cv_drawKeyPoints
       c:@F@cv_drawMatches:
         name: cv_drawMatches
+      c:@F@cv_flann_IndexParams_close:
+        name: cv_flann_IndexParams_close
+      c:@F@cv_flann_IndexParams_create:
+        name: cv_flann_IndexParams_create
+      c:@F@cv_flann_IndexParams_getAll:
+        name: cv_flann_IndexParams_getAll
+      c:@F@cv_flann_IndexParams_getDouble:
+        name: cv_flann_IndexParams_getDouble
+      c:@F@cv_flann_IndexParams_getInt:
+        name: cv_flann_IndexParams_getInt
+      c:@F@cv_flann_IndexParams_getString:
+        name: cv_flann_IndexParams_getString
+      c:@F@cv_flann_IndexParams_params_ptr:
+        name: cv_flann_IndexParams_params_ptr
+      c:@F@cv_flann_IndexParams_setAlgorithm:
+        name: cv_flann_IndexParams_setAlgorithm
+      c:@F@cv_flann_IndexParams_setBool:
+        name: cv_flann_IndexParams_setBool
+      c:@F@cv_flann_IndexParams_setDouble:
+        name: cv_flann_IndexParams_setDouble
+      c:@F@cv_flann_IndexParams_setFloat:
+        name: cv_flann_IndexParams_setFloat
+      c:@F@cv_flann_IndexParams_setInt:
+        name: cv_flann_IndexParams_setInt
+      c:@F@cv_flann_IndexParams_setString:
+        name: cv_flann_IndexParams_setString
       c:@S@AKAZE:
         name: AKAZE
       c:@S@AgastFeatureDetector:
@@ -114,6 +144,8 @@ files:
         name: FastFeatureDetector
       c:@S@FlannBasedMatcher:
         name: FlannBasedMatcher
+      c:@S@FlannIndexParams:
+        name: FlannIndexParams
       c:@S@GFTTDetector:
         name: GFTTDetector
       c:@S@KAZE:
@@ -140,6 +172,8 @@ files:
         name: FastFeatureDetectorPtr
       c:features2d.h@T@FlannBasedMatcherPtr:
         name: FlannBasedMatcherPtr
+      c:features2d.h@T@FlannIndexParamsPtr:
+        name: FlannIndexParamsPtr
       c:features2d.h@T@GFTTDetectorPtr:
         name: GFTTDetectorPtr
       c:features2d.h@T@KAZEPtr:
@@ -162,7 +196,13 @@ files:
         name: VecChar
       c:types.h@T@VecDMatch:
         name: VecDMatch
+      c:types.h@T@VecF64:
+        name: VecF64
+      c:types.h@T@VecI32:
+        name: VecI32
       c:types.h@T@VecKeyPoint:
         name: VecKeyPoint
+      c:types.h@T@VecVecChar:
+        name: VecVecChar
       c:types.h@T@VecVecDMatch:
         name: VecVecDMatch

--- a/packages/dartcv/test/features2d/features2d_test.dart
+++ b/packages/dartcv/test/features2d/features2d_test.dart
@@ -43,14 +43,21 @@ void main() async {
     };
     final params1 = cv.FlannIndexParams.fromMap(map);
     expect(params1.getAll(), map);
+
+    expect(params1.toString(), startsWith("FlannIndexParams(address=0x"));
   });
 
   test('cv.FlannSearchParams', () {
     final params = cv.FlannSearchParams(eps: 1.0, exploreAllTrees: true);
-    expect(params.checks, 32);
-    expect(params.eps, 1.0);
-    expect(params.sorted, true);
-    expect(params.exploreAllTrees, true);
+
+    params.checks = 50;
+    params.eps = 0.5;
+    params.sorted = false;
+    params.exploreAllTrees = false;
+    expect(params.checks, 50);
+    expect(params.eps, 0.5);
+    expect(params.sorted, false);
+    expect(params.exploreAllTrees, false);
     expect(params.toString(), startsWith("FlannSearchParams(address=0x"));
   });
 
@@ -343,12 +350,15 @@ void main() async {
 
     {
       // https://github.com/rainyl/opencv_dart/issues/369
-      final indexParams = cv.FlannIndexParams.fromMap(
-        {
-          'algorithm': cv.FlannAlgorithm.FLANN_INDEX_KDTREE,
-          "trees": 4,
-        },
-      );
+      // final indexParams = cv.FlannIndexParams.fromMap(
+      //   {
+      //     'algorithm': cv.FlannAlgorithm.FLANN_INDEX_KDTREE,
+      //     "trees": 4,
+      //   },
+      // );
+      final indexParams = cv.FlannKDTreeIndexParams();
+      expect(indexParams.toString(), startsWith("FlannKDTreeIndexParams(address=0x"));
+
       final searchParams = cv.FlannSearchParams(checks: 32);
       final matcher = cv.FlannBasedMatcher.create(indexParams: indexParams, searchParams: searchParams);
       final dmatches = matcher.knnMatch(desc11, desc21, 2);

--- a/packages/dartcv/test/features2d/features2d_test.dart
+++ b/packages/dartcv/test/features2d/features2d_test.dart
@@ -10,7 +10,7 @@ void main() async {
     expect(params.get<String>('not exist', "abc"), "abc");
     expect(params.getAll(), {});
 
-    params.setAlgorithm(0);
+    params.setAlgorithm(cv.FlannAlgorithm.FLANN_INDEX_LINEAR);
     params.set<bool>("bool_0", true);
     params.set<double>("double_0", 241.0);
     params.set<int>("int_0", 241);
@@ -27,7 +27,7 @@ void main() async {
 
     final all = params.getAll();
     expect(all, <String, dynamic>{
-      "algorithm": 0,
+      "algorithm": cv.FlannAlgorithm.FLANN_INDEX_LINEAR,
       "bool_0": true,
       "double_0": 241.0,
       "int_0": 241,
@@ -35,7 +35,7 @@ void main() async {
     });
 
     final map = {
-      "algorithm": 0,
+      "algorithm": cv.FlannAlgorithm.FLANN_INDEX_LINEAR,
       "bool_0": true,
       "double_0": 241.0,
       "int_0": 241,
@@ -345,14 +345,11 @@ void main() async {
       // https://github.com/rainyl/opencv_dart/issues/369
       final indexParams = cv.FlannIndexParams.fromMap(
         {
-          // 'algorithm': 6,
-          // 'table_number': 10,
-          // 'key_size': 20,
-          // 'multi_probe_level': 0,
+          'algorithm': cv.FlannAlgorithm.FLANN_INDEX_KDTREE,
           "trees": 4,
         },
       );
-      final searchParams = cv.FlannSearchParams(checks: 50);
+      final searchParams = cv.FlannSearchParams(checks: 32);
       final matcher = cv.FlannBasedMatcher.create(indexParams: indexParams, searchParams: searchParams);
       final dmatches = matcher.knnMatch(desc11, desc21, 2);
       expect(dmatches.length, greaterThan(0));


### PR DESCRIPTION
- bump opencv to 4.12.0
- add `FlannIndexParams`, `FlannSearchParams`
- add `FlannBasedMatcher.create`
- fix: #369 #293 