### PR TITLE
add `replaceWriteLogMessageEx`, support logging to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bak/
 .bak/
 .pytest_cache/
 test/_data/
+test/logs
 ffigen_test/
 replace.py
 generate.py

--- a/lib/src/g/core.g.dart
+++ b/lib/src/g/core.g.dart
@@ -2683,6 +2683,11 @@ external void registerErrorCallback(
   ErrorCallback callback,
 );
 
+@ffi.Native<ffi.Pointer<CvStatus> Function(LogCallbackEx)>()
+external ffi.Pointer<CvStatus> replaceWriteLogMessageEx(
+  LogCallbackEx arg0,
+);
+
 @ffi.Native<ffi.Pointer<CvStatus> Function(ffi.Int)>()
 external ffi.Pointer<CvStatus> setLogLevel(
   int logLevel,
@@ -5618,6 +5623,21 @@ typedef DartErrorCallbackFunction = void Function(
     int line,
     ffi.Pointer<ffi.Void> userdata);
 typedef KeyPoint = imp$1.KeyPoint;
+typedef LogCallbackEx = ffi.Pointer<ffi.NativeFunction<LogCallbackExFunction>>;
+typedef LogCallbackExFunction = ffi.Void Function(
+    ffi.Int logLevel,
+    ffi.Pointer<ffi.Char> tag,
+    ffi.Pointer<ffi.Char> file,
+    ffi.Int line,
+    ffi.Pointer<ffi.Char> func,
+    ffi.Pointer<ffi.Char> message);
+typedef DartLogCallbackExFunction = void Function(
+    int logLevel,
+    ffi.Pointer<ffi.Char> tag,
+    ffi.Pointer<ffi.Char> file,
+    int line,
+    ffi.Pointer<ffi.Char> func,
+    ffi.Pointer<ffi.Char> message);
 typedef Mat = imp$1.Mat;
 typedef MatStep = imp$1.MatStep;
 typedef RNG = imp$1.RNG;

--- a/lib/src/g/core.yaml
+++ b/lib/src/g/core.yaml
@@ -7,6 +7,9 @@ files:
       ErrorCallbackFunction:
         name: ErrorCallbackFunction
         dart-name: DartErrorCallbackFunction
+      LogCallbackExFunction:
+        name: LogCallbackExFunction
+        dart-name: DartLogCallbackExFunction
       c:@F@CvStatus_close:
         name: CvStatus_close
       c:@F@cv_LUT:
@@ -631,6 +634,8 @@ files:
         name: getLogLevel
       c:@F@registerErrorCallback:
         name: registerErrorCallback
+      c:@F@replaceWriteLogMessageEx:
+        name: replaceWriteLogMessageEx
       c:@F@setLogLevel:
         name: setLogLevel
       c:@F@std_VecChar_clear:
@@ -1615,14 +1620,16 @@ files:
         name: std_VecVecPoint_set
       c:@F@std_VecVecPoint_shrink_to_fit:
         name: std_VecVecPoint_shrink_to_fit
-      c:exception.h@T@ErrorCallback:
-        name: ErrorCallback
-      c:math.h@T@double_t:
+      c:@T@double_t:
         name: double_t
         dart-name: Dartdouble_t
-      c:math.h@T@float_t:
+      c:@T@float_t:
         name: float_t
         dart-name: Dartfloat_t
+      c:exception.h@T@ErrorCallback:
+        name: ErrorCallback
+      c:logging.h@T@LogCallbackEx:
+        name: LogCallbackEx
       c:types.h@T@CvPoint:
         name: CvPoint
       c:types.h@T@CvPoint2f:

--- a/test/dnn/dnn_test.dart
+++ b/test/dnn/dnn_test.dart
@@ -2,6 +2,7 @@
 import 'dart:io';
 
 import 'package:dartcv4/dartcv.dart' as cv;
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 bool checkCaffeNet(cv.Net net) {
@@ -143,6 +144,22 @@ bool checkTflite(cv.Net net) {
 }
 
 void main() async {
+  // shows how to log to a file
+  Logger.root.level = Level.ALL;
+  final logFile = File('test/logs/core_test.log');
+  if (!(await logFile.parent.exists())) {
+    await logFile.parent.create(recursive: true);
+  }
+  final logger = Logger('core_test')
+    ..onRecord.listen(
+      (record) => logFile.writeAsStringSync('${record.time}: ${record.message}\n', mode: FileMode.append),
+    );
+  cv.setLogLevel(cv.LOG_LEVEL_DEBUG);
+  cv.replaceWriteLogMessageEx(
+    callback: (logLevel, tag, file, line, func, message) =>
+        logger.warning("[dartcv][$logLevel][$tag]-$file:$line:$func: $message"),
+  );
+
   test('cv.Net.fromFile', () async {
     final net = cv.Net.empty();
     expect(net.isEmpty, true);


### PR DESCRIPTION
fix: #173 

Recently, opencv 4.12.0 adds `replaceWriteLogMessageEx` in https://github.com/opencv/opencv/pull/27154 

Which makes logging to a file possible, now we support user-defined logger

```dart
Logger.root.level = Level.ALL;
final logFile = File('test/logs/core_test.log');
final logger = Logger('core_test')
  ..onRecord.listen(
    (record) => logFile.writeAsStringSync('${record.time}: ${record.message}\n', mode: FileMode.append),
  );
cv.setLogLevel(cv.LOG_LEVEL_DEBUG);
cv.replaceWriteLogMessageEx(
  callback: (logLevel, tag, file, line, func, message) =>
      logger.warning("[dartcv][$logLevel][$tag]-$file:$line:$func: $message"),
);
// set null to restore default behavior as opencv
cv.replaceWriteLogMessageEx(callback: null);
```

Currently, this is only supported in `2.x` branch, will support `1.x` in the future if I have some time.