### PR TITLE
add more custom loggers, support user-defined logger callback

### DIFF
--- a/lib/src/g/core.g.dart
+++ b/lib/src/g/core.g.dart
@@ -3168,6 +3168,9 @@ external ffi.Pointer<ffi.Char> getCvVersion();
 @ffi.Native<LogCallback Function()>()
 external LogCallback getLogCallback();
 
+@ffi.Native<LogCallbackEx Function()>()
+external LogCallbackEx getLogCallbackEx();
+
 @ffi.Native<ffi.Pointer<CvStatus> Function(ffi.Pointer<ffi.Int>)>()
 external ffi.Pointer<CvStatus> getLogLevel(
   ffi.Pointer<ffi.Int> logLevel,
@@ -3176,19 +3179,32 @@ external ffi.Pointer<CvStatus> getLogLevel(
 @ffi.Native<LogCallback>()
 external LogCallback logCallback;
 
+@ffi.Native<LogCallbackEx>()
+external LogCallbackEx logCallbackEx;
+
 @ffi.Native<ffi.Void Function(ErrorCallback)>()
 external void registerErrorCallback(
   ErrorCallback callback,
 );
 
 @ffi.Native<ffi.Pointer<CvStatus> Function(LogCallback)>()
-external ffi.Pointer<CvStatus> replaceWriteLogMessageEx(
+external ffi.Pointer<CvStatus> replaceWriteLogMessage(
   LogCallback callback,
+);
+
+@ffi.Native<ffi.Pointer<CvStatus> Function(LogCallbackEx)>()
+external ffi.Pointer<CvStatus> replaceWriteLogMessageEx(
+  LogCallbackEx callback,
 );
 
 @ffi.Native<ffi.Void Function(LogCallback)>()
 external void setLogCallback(
   LogCallback callback,
+);
+
+@ffi.Native<ffi.Void Function(LogCallbackEx)>()
+external void setLogCallbackEx(
+  LogCallbackEx callback,
 );
 
 @ffi.Native<ffi.Pointer<CvStatus> Function(ffi.Int)>()
@@ -6016,6 +6032,24 @@ external void std_VecVecPoint_shrink_to_fit(
   ffi.Pointer<VecVecPoint> self,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Int, ffi.Pointer<ffi.Char>)>()
+external void writeLogMessage(
+  int logLevel,
+  ffi.Pointer<ffi.Char> message,
+);
+
+@ffi.Native<
+    ffi.Void Function(ffi.Int, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Char>,
+        ffi.Int, ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Char>)>()
+external void writeLogMessageEx(
+  int logLevel,
+  ffi.Pointer<ffi.Char> tag,
+  ffi.Pointer<ffi.Char> file,
+  int line,
+  ffi.Pointer<ffi.Char> func,
+  ffi.Pointer<ffi.Char> message,
+);
+
 const addresses = _SymbolAddresses();
 
 class _SymbolAddresses {
@@ -6129,7 +6163,8 @@ typedef DartErrorCallbackFunction = void Function(
     ffi.Pointer<ffi.Void> userdata);
 typedef KeyPoint = imp$1.KeyPoint;
 typedef LogCallback = ffi.Pointer<ffi.NativeFunction<LogCallbackFunction>>;
-typedef LogCallbackFunction = ffi.Void Function(
+typedef LogCallbackEx = ffi.Pointer<ffi.NativeFunction<LogCallbackExFunction>>;
+typedef LogCallbackExFunction = ffi.Void Function(
     ffi.Int logLevel,
     ffi.Pointer<ffi.Char> tag,
     ffi.Size tagLen,
@@ -6140,7 +6175,7 @@ typedef LogCallbackFunction = ffi.Void Function(
     ffi.Size funcLen,
     ffi.Pointer<ffi.Char> message,
     ffi.Size msgLen);
-typedef DartLogCallbackFunction = void Function(
+typedef DartLogCallbackExFunction = void Function(
     int logLevel,
     ffi.Pointer<ffi.Char> tag,
     int tagLen,
@@ -6151,6 +6186,10 @@ typedef DartLogCallbackFunction = void Function(
     int funcLen,
     ffi.Pointer<ffi.Char> message,
     int msgLen);
+typedef LogCallbackFunction = ffi.Void Function(
+    ffi.Int logLevel, ffi.Pointer<ffi.Char> message, ffi.Size msgLen);
+typedef DartLogCallbackFunction = void Function(
+    int logLevel, ffi.Pointer<ffi.Char> message, int msgLen);
 typedef Mat = imp$1.Mat;
 typedef MatStep = imp$1.MatStep;
 typedef RNG = imp$1.RNG;

--- a/lib/src/g/core.yaml
+++ b/lib/src/g/core.yaml
@@ -7,6 +7,9 @@ files:
       ErrorCallbackFunction:
         name: ErrorCallbackFunction
         dart-name: DartErrorCallbackFunction
+      LogCallbackExFunction:
+        name: LogCallbackExFunction
+        dart-name: DartLogCallbackExFunction
       LogCallbackFunction:
         name: LogCallbackFunction
         dart-name: DartLogCallbackFunction
@@ -752,14 +755,20 @@ files:
         name: getCvVersion
       c:@F@getLogCallback:
         name: getLogCallback
+      c:@F@getLogCallbackEx:
+        name: getLogCallbackEx
       c:@F@getLogLevel:
         name: getLogLevel
       c:@F@registerErrorCallback:
         name: registerErrorCallback
+      c:@F@replaceWriteLogMessage:
+        name: replaceWriteLogMessage
       c:@F@replaceWriteLogMessageEx:
         name: replaceWriteLogMessageEx
       c:@F@setLogCallback:
         name: setLogCallback
+      c:@F@setLogCallbackEx:
+        name: setLogCallbackEx
       c:@F@setLogLevel:
         name: setLogLevel
       c:@F@std_VecChar_clear:
@@ -1744,12 +1753,20 @@ files:
         name: std_VecVecPoint_set
       c:@F@std_VecVecPoint_shrink_to_fit:
         name: std_VecVecPoint_shrink_to_fit
+      c:@F@writeLogMessage:
+        name: writeLogMessage
+      c:@F@writeLogMessageEx:
+        name: writeLogMessageEx
       c:@logCallback:
         name: logCallback
+      c:@logCallbackEx:
+        name: logCallbackEx
       c:exception.h@T@ErrorCallback:
         name: ErrorCallback
       c:logging.h@T@LogCallback:
         name: LogCallback
+      c:logging.h@T@LogCallbackEx:
+        name: LogCallbackEx
       c:math.h@T@double_t:
         name: double_t
         dart-name: Dartdouble_t

--- a/test/core/core_test.dart
+++ b/test/core/core_test.dart
@@ -1,18 +1,39 @@
 // ignore_for_file: avoid_print
+import 'dart:isolate';
+
 import 'package:dartcv4/dartcv.dart' as cv;
 import 'package:test/test.dart';
 
 void main() async {
   test('setLogLevel', () {
-    cv.setLogLevel(cv.LOG_LEVEL_ERROR);
+    cv.setLogLevel(cv.LogLevel.ERROR);
     final level = cv.getLogLevel();
-    expect(level, equals(cv.LOG_LEVEL_ERROR));
+    expect(level, equals(cv.LogLevel.ERROR));
   });
 
   test('getLogLevel', () {
-    cv.setLogLevel(cv.LOG_LEVEL_WARNING);
+    cv.setLogLevel(cv.LogLevel.WARNING);
     final level = cv.getLogLevel();
-    expect(level, equals(cv.LOG_LEVEL_WARNING));
+    expect(level, equals(cv.LogLevel.WARNING));
+  });
+
+  test('cv.replaceWriteLogMessage', () {
+    cv.setLogLevel(cv.LogLevel.DEBUG);
+    cv.replaceWriteLogMessage(callback: cv.defaultLogCallback);
+    Isolate.run(() async {
+      cv.writeLogMessage(cv.LogLevel.DEBUG, 'This is a test log message.');
+    });
+    // reset log callback
+    cv.replaceWriteLogMessage(callback: null);
+  });
+
+  test('cv.replaceWriteLogMessageEx', () {
+    cv.setLogLevel(cv.LogLevel.DEBUG);
+    cv.replaceWriteLogMessageEx(callback: cv.defaultLogCallbackEx);
+    Isolate.run(() async {
+      cv.writeLogMessageEx(cv.LogLevel.DEBUG, 'This is a test log message.', file: "core_test.dart");
+    });
+    cv.replaceWriteLogMessageEx(callback: null);
   });
 
   test('openCvVersion', () async {

--- a/test/core/core_test.dart
+++ b/test/core/core_test.dart
@@ -18,20 +18,20 @@ void main() async {
   });
 
   test('cv.replaceWriteLogMessage', () {
-    cv.setLogLevel(cv.LogLevel.DEBUG);
+    cv.setLogLevel(cv.LogLevel.WARNING);
     cv.replaceWriteLogMessage(callback: cv.defaultLogCallback);
     Isolate.run(() async {
-      cv.writeLogMessage(cv.LogLevel.DEBUG, 'This is a test log message.');
+      cv.writeLogMessage(cv.LogLevel.WARNING, 'This is a test log message.');
     });
     // reset log callback
     cv.replaceWriteLogMessage(callback: null);
   });
 
   test('cv.replaceWriteLogMessageEx', () {
-    cv.setLogLevel(cv.LogLevel.DEBUG);
+    cv.setLogLevel(cv.LogLevel.WARNING);
     cv.replaceWriteLogMessageEx(callback: cv.defaultLogCallbackEx);
     Isolate.run(() async {
-      cv.writeLogMessageEx(cv.LogLevel.DEBUG, 'This is a test log message.', file: "core_test.dart");
+      cv.writeLogMessageEx(cv.LogLevel.WARNING, 'This is a test log message.', file: "core_test.dart");
     });
     cv.replaceWriteLogMessageEx(callback: null);
   });


### PR DESCRIPTION
fix: #173 

Recently, opencv 4.12.0 adds `replaceWriteLogMessage` abd `replaceWriteLogMessageEx` in https://github.com/opencv/opencv/pull/27154 

Which makes logging to a file possible, now we support user-defined logger

```dart
import 'dart:io';
import 'dart:isolate';

import 'package:dartcv4/dartcv.dart' as cv;
import 'package:logging/logging.dart';

void main(List<String> args) async {
  final logFile = File("log.txt");
  final logger = Logger("")
    ..level = Level.ALL
    ..onRecord.listen((record) {
      logFile.writeAsStringSync("${record.message}\n", mode: FileMode.append);
    });

  cv.setLogLevel(cv.LogLevel.DEBUG);
  cv.replaceWriteLogMessage(
    callback: (level, message) {
      logger.warning(message);
    },
  );

  await Isolate.run<void>(
    () {
      for (var i = 0; i < 100; i++) {
        cv.writeLogMessage(cv.LogLevel.ERROR, "$i hello world");
      }
    },
  );

  print("isolate done");

  cv.replaceWriteLogMessage(callback: null);
}

```

Currently, this is only supported in `2.x` branch, will support `1.x` in the future if I have some time.