### PR TITLE
fix: windows CI

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           channel: "stable"
       - name: test coverage
+        shell: pwsh
         run: |
           cd "${{github.workspace}}\packages\dartcv"
           dart pub global activate coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
           out-file-path: "test/"
           extract: true
       - name: Run Test
+        shell: pwsh
         run: |
           dart pub get
           dart test -x skip-workflow

--- a/packages/dartcv/CHANGELOG.md
+++ b/packages/dartcv/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.1
+
+- support setting custom cmake generator
+- fix: Skip native build hook for web builds
+- new: support enumerating videoio backends
+
 ## 2.2.0
 
 - breaking change: support building from opencv source code, it's now the default behavior, since this version, prebuilt opencv static binary is no longer included.

--- a/packages/dartcv/pubspec.yaml
+++ b/packages/dartcv/pubspec.yaml
@@ -31,8 +31,6 @@ hooks:
     # this is for development and debug, not seen in production
     dartcv4:
       debug: true
-      windows:
-        generator: "Visual Studio 18 2026"
       linux:
         generator: "Unix Makefiles"
       macos:

--- a/packages/dartcv/pubspec.yaml
+++ b/packages/dartcv/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartcv4
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 2.2.0
+version: 2.2.1
 opencv_version: 4.13.0
 homepage: https://github.com/rainyl/opencv_dart
 
@@ -12,11 +12,9 @@ dependencies:
   ffi: ^2.1.4
   hooks: ^1.0.0
   logging: ^1.3.0
-  native_toolchain_cmake: ^0.2.2
+  native_toolchain_cmake: ^0.2.3
   # native_toolchain_cmake:
   #   path: ../native_toolchain_cmake
-  path: ^1.9.1
-  yaml: ^3.1.3
 
 dev_dependencies:
   ffigen: ^20.1.1


### PR DESCRIPTION
ci: specify PowerShell shell for test steps in workflows

Update publish and coverage workflows to explicitly use PowerShell (pwsh) for test steps to ensure consistent execution environment across platforms.

Update dartcv package to version 2.2.1, bump native_toolchain_cmake dependency, and remove unused path and yaml dependencies.