### PR TITLE
fix(build): ensure opencv-contrib modules path is set correctly

### DIFF
--- a/packages/dartcv/CHANGELOG.md
+++ b/packages/dartcv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dartcv
 
+## 2.2.1+3
+
+- fix: opencv-contrib modules are not correctly built when changing include modules.
+
 ## 2.2.1+2
 
 - fix: Explicitly disable building unused modules to reduce build time.

--- a/packages/dartcv/pubspec.yaml
+++ b/packages/dartcv/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartcv4
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 2.2.1+2
+version: 2.2.1+3
 opencv_version: 4.13.0
 homepage: https://github.com/rainyl/opencv_dart
 

--- a/packages/dartcv/src/CMakeLists.txt
+++ b/packages/dartcv/src/CMakeLists.txt
@@ -114,7 +114,7 @@ if(DARTCV_BUILD_OPENCV_FROM_SOURCE)
       URL https://github.com/opencv/opencv_contrib/archive/refs/tags/${OPENCV_VERSION}.tar.gz
     )
     FetchContent_MakeAvailable(opencv_contrib)
-    set(OPENCV_EXTRA_MODULES_PATH ${opencv_contrib_SOURCE_DIR}/modules CACHE PATH "Path to opencv_contrib modules")
+    set(OPENCV_EXTRA_MODULES_PATH ${opencv_contrib_SOURCE_DIR}/modules CACHE PATH "Path to opencv_contrib modules" FORCE)
   endif()
 
   FetchContent_Declare(

--- a/packages/opencv_dart/CHANGELOG.md
+++ b/packages/opencv_dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # opencv_dart
 
+## 2.2.1+3
+
+- fix: opencv-contrib modules are not correctly built when changing include modules.
+
 ## 2.2.1+2
 
 - fix: Explicitly disable building unused modules to reduce build time.

--- a/packages/opencv_dart/pubspec.yaml
+++ b/packages/opencv_dart/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opencv_dart
 description: |
   OpenCV4 bindings for Flutter, using dart:ffi.
-version: 2.2.1+2
+version: 2.2.1+3
 opencv_version: 4.13.0
 repository: https://github.com/rainyl/opencv_dart
 homepage: https://github.com/rainyl/opencv_dart/tree/main/packages/opencv_dart

--- a/packages/opencv_dart/pubspec.yaml
+++ b/packages/opencv_dart/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dartcv4: ^2.2.1+2
+  dartcv4: ^2.2.1+3
   # dartcv4:
   #   path: ../dartcv
 


### PR DESCRIPTION
fixes: #423 

When building OpenCV from source with contrib modules, the OPENCV_EXTRA_MODULES_PATH variable was not being forced, causing builds to ignore changes to the included modules list. This adds the FORCE flag to the cache setting, ensuring the correct modules are built when the configuration changes.