### PR TITLE
fix: ensure aruco module is correctly built with required dependencies

### DIFF
--- a/packages/dartcv/CHANGELOG.md
+++ b/packages/dartcv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dartcv
 
+## 2.2.1+4
+
+- fix: aruco module is not correctly built when changing include modules.
+
 ## 2.2.1+3
 
 - fix: opencv-contrib modules are not correctly built when changing include modules.

--- a/packages/dartcv/pubspec.yaml
+++ b/packages/dartcv/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartcv4
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 2.2.1+3
+version: 2.2.1+4
 opencv_version: 4.13.0
 homepage: https://github.com/rainyl/opencv_dart
 

--- a/packages/dartcv/src/cmake/opencv_options.cmake
+++ b/packages/dartcv/src/cmake/opencv_options.cmake
@@ -175,7 +175,7 @@ if(DARTCV_WITH_ARUCO)
   set(BUILD_opencv_aruco ON CACHE BOOL "Build aruco module" FORCE)
   set(BUILD_opencv_imgproc ON CACHE BOOL "Build imgproc module" FORCE)
   set(BUILD_opencv_calib3d ON CACHE BOOL "Build calib3d module" FORCE)
-  set(BUILD_opencv_features2d ON CACHE BOOL "Build features2d module" FORCE)
+  set(BUILD_opencv_objdetect ON CACHE BOOL "Build objdetect module" FORCE)
 endif()
 
 if(DARTCV_WITH_IMG_HASH)

--- a/packages/opencv_dart/CHANGELOG.md
+++ b/packages/opencv_dart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # opencv_dart
 
+## 2.2.1+4
+
+- fix: aruco module is not correctly built when changing include modules.
+
 ## 2.2.1+3
 
 - fix: opencv-contrib modules are not correctly built when changing include modules.

--- a/packages/opencv_dart/pubspec.yaml
+++ b/packages/opencv_dart/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opencv_dart
 description: |
   OpenCV4 bindings for Flutter, using dart:ffi.
-version: 2.2.1+3
+version: 2.2.1+4
 opencv_version: 4.13.0
 repository: https://github.com/rainyl/opencv_dart
 homepage: https://github.com/rainyl/opencv_dart/tree/main/packages/opencv_dart


### PR DESCRIPTION
fixes: #427 

Update CMake configuration to include the correct dependency (objdetect) for the aruco module when it is enabled. This resolves a build issue where the aruco module would not compile properly when changing included modules. Also update package versions and changelogs accordingly.