### PR TITLE
chore: bump version to 2.2.2 and update documentation

### DIFF
--- a/packages/dartcv/CHANGELOG.md
+++ b/packages/dartcv/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dartcv
 
+## 2.2.2
+
+- new: add `LineSegmentDetector` support (imgproc module)
+- bump `native_toolchain_cmake` to `0.2.5`
+
 ## 2.2.1+4
 
 - fix: aruco module is not correctly built when changing include modules.

--- a/packages/dartcv/README.md
+++ b/packages/dartcv/README.md
@@ -122,9 +122,9 @@ void main() async {
 
 #### Flutter
 
-see [example](https://github.com/rainyl/opencv_dart/tree/2.x/example/flutter)
+see [example](https://github.com/rainyl/opencv_dart/tree/main/packages/dartcv/example/flutter)
 
-~~More examples are on the way...~~ see [opencv_dart.examples](https://github.com/rainyl/opencv_dart.examples) and share yours
+~~More examples are on the way...~~ see [awesome-opencv_dart](https://github.com/rainyl/awesome-opencv_dart) and share yours
 
 #### Configure hooks options
 
@@ -234,6 +234,13 @@ hooks:
             </td>
 		</tr>
 		<tr>
+            <td align="center">
+                <a href="https://github.com/dupuchba">
+                    <img src="https://avatars.githubusercontent.com/u/911705?v=4" width="100;" alt="dupuchba"/>
+                    <br />
+                    <sub><b>Baptiste DUPUCH</b></sub>
+                </a>
+            </td>
             <td align="center">
                 <a href="https://github.com/Escaton615">
                     <img src="https://avatars.githubusercontent.com/u/6680284?v=4" width="100;" alt="Escaton615"/>

--- a/packages/dartcv/pubspec.yaml
+++ b/packages/dartcv/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartcv4
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 2.2.1+4
+version: 2.2.2
 opencv_version: 4.13.0
 homepage: https://github.com/rainyl/opencv_dart
 
@@ -12,7 +12,7 @@ dependencies:
   ffi: ^2.1.4
   hooks: ^1.0.0
   logging: ^1.3.0
-  native_toolchain_cmake: ^0.2.4
+  native_toolchain_cmake: ^0.2.5
   # native_toolchain_cmake:
   #   path: ../native_toolchain_cmake
 

--- a/packages/opencv_dart/CHANGELOG.md
+++ b/packages/opencv_dart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # opencv_dart
 
+## 2.2.2
+
+- new: add `LineSegmentDetector` support (imgproc module)
+- bump `native_toolchain_cmake` to `0.2.5`
+
 ## 2.2.1+4
 
 - fix: aruco module is not correctly built when changing include modules.

--- a/packages/opencv_dart/README.md
+++ b/packages/opencv_dart/README.md
@@ -124,9 +124,9 @@ void main() async {
 
 #### Flutter
 
-see [example](https://github.com/rainyl/opencv_dart/tree/2.x/example/flutter)
+see [example](https://github.com/rainyl/opencv_dart/tree/main/packages/opencv_dart/example)
 
-~~More examples are on the way...~~ see [opencv_dart.examples](https://github.com/rainyl/opencv_dart.examples) and share yours
+~~More examples are on the way...~~ see [awesome-opencv_dart](https://github.com/rainyl/awesome-opencv_dart) and share yours
 
 #### Configure hooks options
 
@@ -235,6 +235,13 @@ hooks:
                 </a>
             </td>
     </tr>
+            <td align="center">
+                <a href="https://github.com/dupuchba">
+                    <img src="https://avatars.githubusercontent.com/u/911705?v=4" width="100;" alt="dupuchba"/>
+                    <br />
+                    <sub><b>Baptiste DUPUCH</b></sub>
+                </a>
+            </td>
     <tr>
             <td align="center">
                 <a href="https://github.com/Escaton615">

--- a/packages/opencv_dart/pubspec.yaml
+++ b/packages/opencv_dart/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opencv_dart
 description: |
   OpenCV4 bindings for Flutter, using dart:ffi.
-version: 2.2.1+4
+version: 2.2.2
 opencv_version: 4.13.0
 repository: https://github.com/rainyl/opencv_dart
 homepage: https://github.com/rainyl/opencv_dart/tree/main/packages/opencv_dart
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dartcv4: ^2.2.1+3
+  dartcv4: ^2.2.2
   # dartcv4:
   #   path: ../dartcv
 


### PR DESCRIPTION
- Add `LineSegmentDetector` support to the imgproc module
- Update `native_toolchain_cmake` dependency to ^0.2.5
- Correct example links and add contributor to README files