### PR TITLE
feat: add skip_build user define to bypass native build for CI unit tests

### DIFF
--- a/packages/dartcv/CHANGELOG.md
+++ b/packages/dartcv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dartcv
 
+## 2.3.1
+
+- new: add `skip_build` hook user-define to bypass the native build entirely, for CI unit-test runs that never call into dartcv4's native code
+
 ## 2.3.0
 
 - new: memory-safety fixes:

--- a/packages/dartcv/CHANGELOG.md
+++ b/packages/dartcv/CHANGELOG.md
@@ -1,9 +1,5 @@
 # dartcv
 
-## 2.3.1
-
-- new: add `skip_build` hook user-define to bypass the native build entirely, for CI unit-test runs that never call into dartcv4's native code
-
 ## 2.3.0
 
 - new: memory-safety fixes:
@@ -20,6 +16,7 @@
 - new: add `CharucoBoard` / `CharucoDetector` bindings (contrib module)
 - fix(videoio): free native-allocated arrays in backend registry getters (memory leak); make `hasBackend` / `isBackendBuiltIn` exception-safe; skip unknown backend values in `getBackends`-family via `VideoCaptureAPIs.maybeFromValue`; always release probed cameras in `enumerateCameras`; support `16F` in `parseFrameFormat`
 - fix(videoio): writer tests write to per-test temp dirs (no shared-file race between parallel test files); silence OpenCV backend-probing warnings in videoio tests
+- new: add `skip_build` hook user-define to bypass the native build entirely, for CI unit-test runs that never call into dartcv4's native code
 
 ## 2.2.2
 

--- a/packages/dartcv/lib/src/hook_helpers/run_build.dart
+++ b/packages/dartcv/lib/src/hook_helpers/run_build.dart
@@ -44,6 +44,13 @@ const allowedModules = {
 };
 
 Future<void> runBuild(BuildInput input, BuildOutputBuilder output, {Set<String>? optionalModules}) async {
+  // Consumers can set `hooks.user_defines.dartcv4.skip_build: true` in their pubspec.yaml
+  // to skip the native build entirely (e.g. for unit test runs that never call into
+  // dartcv4's native code, where compiling/downloading OpenCV is pure CI overhead).
+  if (input.userDefines['skip_build'] == true) {
+    return;
+  }
+
   // Check if code assets are expected (not for web builds).
   // Web builds use WASM/JS interop, not native code assets.
   if (!input.config.buildCodeAssets) {

--- a/packages/dartcv/pubspec.yaml
+++ b/packages/dartcv/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartcv4
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 2.3.1
+version: 2.3.0
 opencv_version: 4.13.0
 homepage: https://github.com/rainyl/opencv_dart
 

--- a/packages/dartcv/pubspec.yaml
+++ b/packages/dartcv/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartcv4
 description: "OpenCV4 bindings for Dart language and Flutter, using dart:ffi. The most complete OpenCV bindings for Dart!"
-version: 2.3.0
+version: 2.3.1
 opencv_version: 4.13.0
 homepage: https://github.com/rainyl/opencv_dart
 

--- a/packages/opencv_dart/CHANGELOG.md
+++ b/packages/opencv_dart/CHANGELOG.md
@@ -16,6 +16,7 @@
 - new: add `CharucoBoard` / `CharucoDetector` bindings (contrib module)
 - fix(videoio): free native-allocated arrays in backend registry getters (memory leak); make `hasBackend` / `isBackendBuiltIn` exception-safe; skip unknown backend values in `getBackends`-family via `VideoCaptureAPIs.maybeFromValue`; always release probed cameras in `enumerateCameras`; support `16F` in `parseFrameFormat`
 - fix(videoio): writer tests write to per-test temp dirs (no shared-file race between parallel test files); silence OpenCV backend-probing warnings in videoio tests
+- new: add `skip_build` hook user-define to bypass the native build entirely, for CI unit-test runs that never call into dartcv4's native code
 
 ## 2.2.2
 


### PR DESCRIPTION
My CI pipeline runs unit tests that never call into dartcv4's native code, so compiling OpenCV for those runs is pure CI overhead. This PR allows CI script to inject `skip_build: true` into `pubspec.yaml` before running `flutter test` to skip the slow native build process.

skip_build in `pubspec.yaml`:
```
hooks:
  user_defines:
    dartcv4:
      skip_build: true
```
