### PR TITLE
feat(hooks): let projects choose which OpenCV to build against

### DIFF
--- a/packages/dartcv/README.md
+++ b/packages/dartcv/README.md
@@ -161,6 +161,18 @@ its bindings are developed and tested against. Two options change that, for
 projects that need a specific OpenCV — usually because their results have to
 match another environment, such as a Python service processing the same images.
 
+> [!WARNING]
+> The pinned version is the only one dartcv is developed and tested against.
+> OpenCV changes its API between releases, so a different version may fail to
+> compile, fail to link, or build cleanly and then behave differently at
+> runtime. **Problems that come from a non-default OpenCV are not supported by
+> opencv_dart**: before reporting one, reproduce it with the pinned version,
+> and if it only happens with yours, it is yours to carry.
+>
+> Use these options when you have a reason to accept that — matching another
+> environment's results, or a platform SDK you do not control — and pin the
+> version you tested, rather than tracking whatever is newest.
+
 - `opencv_version`: build this upstream tag from source instead of the pinned
   one, for example `"4.12.0"`. Must be 4.12 or newer; dartcv calls APIs that do
   not exist before then, and the build stops with a message saying so.

--- a/packages/dartcv/README.md
+++ b/packages/dartcv/README.md
@@ -149,7 +149,39 @@ hooks:
         use_opencl: false
       linux:
         use_opencl: true
+      # which OpenCV to build against, see below
+      # opencv_version: "4.12.0"
+      # opencv_dir: /path/to/opencv/lib/cmake/opencv4
 ```
+
+### Choosing which OpenCV to build against
+
+By default dartcv builds the OpenCV version this package pins, which is the one
+its bindings are developed and tested against. Two options change that, for
+projects that need a specific OpenCV — usually because their results have to
+match another environment, such as a Python service processing the same images.
+
+- `opencv_version`: build this upstream tag from source instead of the pinned
+  one, for example `"4.12.0"`. Must be 4.12 or newer; dartcv calls APIs that do
+  not exist before then, and the build stops with a message saying so.
+- `opencv_dir`: use an OpenCV that is already built, given as the directory
+  holding `OpenCVConfig.cmake`. Takes precedence over `opencv_version`, and can
+  also be set per platform, since a cross-compiled OpenCV lives somewhere
+  different for each target:
+
+```yaml
+hooks:
+  user_defines:
+    dartcv4:
+      include_modules:
+        - ximgproc
+      android:
+        opencv_dir: /path/to/OpenCV-android-sdk/sdk/native/jni
+      ios:
+        opencv_dir: /path/to/opencv-ios/device-arm64/lib/cmake/opencv4
+```
+
+Neither option changes anything for projects that do not set them.
 
 - `debug`: enable debug mode, default is `false`, if enabled, all messages will be printed to stderr.
 - `treeshake`: enable linker dead-code elimination, default is `false`. When enabled, the native library is compiled with function-level sections and the linker garbage-collects code that is not reachable from the exported symbols.

--- a/packages/dartcv/lib/src/hook_helpers/run_build.dart
+++ b/packages/dartcv/lib/src/hook_helpers/run_build.dart
@@ -64,6 +64,15 @@ Future<void> runBuild(BuildInput input, BuildOutputBuilder output, {Set<String>?
   final parallelJobs = userDefines["parallel_jobs"] as int? ?? Platform.numberOfProcessors;
   final includeModules = userDefines["include_modules"] as List?;
   final excludeModules = userDefines["exclude_modules"] as List?;
+  // Which OpenCV to build against.
+  //
+  // `opencv_version` builds that upstream tag from source instead of the
+  // version this package pins, for consumers who need their results to match
+  // another environment running a specific OpenCV. `opencv_dir` points at an
+  // OpenCV that is already built — it wins over `opencv_version`, and may also
+  // be given per platform, since a cross-compiled OpenCV lives in a different
+  // place for each target.
+  final opencvVersion = userDefines["opencv_version"] as String?;
   final platformDefines = {
     OS.windows: userDefines["windows"] as Map<String, dynamic>?,
     OS.linux: userDefines["linux"] as Map<String, dynamic>?,
@@ -77,6 +86,7 @@ Future<void> runBuild(BuildInput input, BuildOutputBuilder output, {Set<String>?
   // Reads `use_opencl` from the platform-specific user defines
   // (e.g. `hooks.user_defines.dartcv4.windows.use_opencl` in pubspec.yaml).
   // Defaults to false when unspecified; always false on iOS (not supported).
+  final opencvDir = (platformDefines[targetOS]?['opencv_dir'] ?? userDefines['opencv_dir']) as String?;
   final useOpenCL = targetOS != OS.iOS && (platformDefines[targetOS]?['use_opencl'] as bool? ?? false);
 
   // Whether to enable linker dead-code elimination (`DARTCV_TREESHAKE`).
@@ -114,6 +124,11 @@ Future<void> runBuild(BuildInput input, BuildOutputBuilder output, {Set<String>?
   logger.info("[dartcv4] exclude modules: $excludeModulesFiltered\n");
   logger.info("[dartcv4] merged modules: $modules\n");
   logger.info("[dartcv4] platform defines: $platformDefines\n");
+  if (opencvDir != null) {
+    logger.info("[dartcv4] using the OpenCV in: $opencvDir\n");
+  } else if (opencvVersion != null) {
+    logger.info("[dartcv4] building OpenCV $opencvVersion from source\n");
+  }
 
   final moduleDefines = {
     'DARTCV_WITH_CALIB3D': modules.contains('calib3d') ? 'ON' : 'OFF',
@@ -164,6 +179,14 @@ Future<void> runBuild(BuildInput input, BuildOutputBuilder output, {Set<String>?
       if (!useOpenCL) 'WITH_OPENCLAMDFFT': 'OFF',
       if (targetOS == OS.iOS || targetOS == OS.macOS) 'WITH_OPENCL_SVM': 'OFF',
       // 'FFMPEG_USE_STATIC_LIBS': 'OFF',
+      if (opencvDir != null) ...{
+        'DARTCV_BUILD_OPENCV_FROM_SOURCE': 'OFF',
+        'DARTCV_DISABLE_DOWNLOAD_OPENCV': 'ON',
+        'OpenCV_DIR': opencvDir,
+      } else if (opencvVersion != null) ...{
+        'DARTCV_BUILD_OPENCV_FROM_SOURCE': 'ON',
+        'OPENCV_VERSION': opencvVersion,
+      },
       'DARTCV_ENABLE_INSTALL': 'ON',
       'DARTCV_TREESHAKE': treeshake ? 'ON' : 'OFF',
       if (keepFile != null) 'DARTCV_KEEP_FILE': keepFile,

--- a/packages/dartcv/src/CMakeLists.txt
+++ b/packages/dartcv/src/CMakeLists.txt
@@ -67,7 +67,14 @@ macro(_find_version _version_var _version_file _regex_find _regex_replace)
 endmacro()
 
 _find_version(PROJECT_VERSION "${PROJ_DIR}/pubspec.yaml" "^version: (.+)*$" "version: (.+)*$")
-_find_version(OPENCV_VERSION "${PROJ_DIR}/pubspec.yaml" "^opencv_version: (.+)*$" "opencv_version: (.+)*$")
+
+# The pubspec records the OpenCV this package is developed against, and is the
+# default. A caller that asked for a different one — -DOPENCV_VERSION, or
+# `opencv_version` in a project's hooks — has already set it, so reading the
+# pubspec here would silently discard that choice.
+if(NOT OPENCV_VERSION)
+  _find_version(OPENCV_VERSION "${PROJ_DIR}/pubspec.yaml" "^opencv_version: (.+)*$" "opencv_version: (.+)*$")
+endif()
 
 # Set OpenCV version
 if(NOT OPENCV_VERSION)


### PR DESCRIPTION
### Summary

dartcv builds the OpenCV version this package pins, which is the right default. But there is no way for a project to ask for a different one, and some need to: a Flutter client whose image processing has to agree with a backend service pinned to a given OpenCV cannot accept whichever version the package tracks, because results move between releases. Binarization is a good example — a threshold computed slightly differently flips pixels, not fractions of pixels.

The CMake side already supports every variant of this:

| variable | effect |
| --- | --- |
| `DARTCV_BUILD_OPENCV_FROM_SOURCE` + `OPENCV_VERSION` | build a given upstream tag |
| `DARTCV_DISABLE_DOWNLOAD_OPENCV` + `OpenCV_DIR` | use an OpenCV that already exists |
| `DARTCV_OPENCV_VERSION` | pick the pre-built release |

None of them is reachable from a `pubspec.yaml`, because the hook does not pass them. Setting them by hand means threading environment variables through Gradle, CocoaPods and the hook runner, which is not something a project can depend on.

This adds two user defines that map onto the machinery already there:

```yaml
hooks:
  user_defines:
    dartcv4:
      include_modules:
        - ximgproc
      opencv_version: "4.12.0"    # build this tag from source
      # or, per platform:
      android:
        opencv_dir: /path/to/OpenCV-android-sdk/sdk/native/jni
      ios:
        opencv_dir: /path/to/opencv-ios/device-arm64/lib/cmake/opencv4
```

`opencv_dir` is also accepted at the top level, and takes precedence over `opencv_version`. Projects that set neither build exactly as they do today — the defines are only emitted when the keys are present.

### Verified end to end

A Dart project depending on this branch, with `opencv_dir` pointing at an OpenCV 4.12.0 I built separately:

```
$ dart run bin/main.dart
Running build hooks...
OpenCV en uso: 4.12.0
Sauvola sobre 8x8 -> 8x8
```

`openCvVersion()` reports **4.12.0**, while this package pins 4.13.0 — so the OpenCV named in the pubspec is the one that ended up linked, and `ximgproc.niBlackThreshold` runs against it.

### Why `opencv_dir` is per platform

An OpenCV cross-compiled for Android and one for iOS are separate trees, and on iOS device and simulator are separate again. A single path cannot serve a multi-platform project, so the key is read from the platform map first and falls back to the top level.

### Note on the minimum version

`opencv_version` accepts any upstream tag, but not every tag works: dartcv calls APIs added in 4.12, so older ones fail to compile. #451 turns that into a clear message at configure time instead of a wall of C++ errors. This PR does not depend on it, but the two are better together — without it, a project that asks for 4.10 here gets 11 errors that never mention the version.

I am happy to rename the keys, nest them under an `opencv:` map, or narrow this to `opencv_dir` only if you would rather not encourage building arbitrary versions from source.
